### PR TITLE
Low Level Input Implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1489fcb93a5bb47da0462ca93ad252ad6af2145cce58d10d46a83931ba9f016b"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +263,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "evdev"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21eef104bd659ef808f1f84bed9a924e1aebcdd066845b377cd3b52cc497bb9f"
+dependencies = [
+ "bitvec",
+ "futures-core",
+ "libc",
+ "nix",
+ "tokio",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,10 +291,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -293,6 +360,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,9 +388,13 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -364,6 +446,28 @@ checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "inotify"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf888f9575c290197b2c948dc9e9ff10bd1a39ad1ea8585f734585fa6b9d3f9"
+dependencies = [
+ "bitflags",
+ "futures-core",
+ "inotify-sys",
+ "libc",
+ "tokio",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -495,6 +599,14 @@ version = "0.0.1"
 [[package]]
 name = "odilia-input"
 version = "0.0.1"
+dependencies = [
+ "evdev",
+ "futures",
+ "futures-core",
+ "inotify",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "odilia-tts"
@@ -638,6 +750,12 @@ checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -819,6 +937,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
@@ -1044,6 +1168,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "zbus"

--- a/input/Cargo.toml
+++ b/input/Cargo.toml
@@ -14,6 +14,9 @@ publish = false
 
 [dependencies]
 evdev = { version = "0.11.4", features = ["tokio"] }
+futures = "0.3.21"
+futures-core = "0.3.21"
+inotify = "0.10.0"
 tokio = { version = "1.16.1", features = ["fs", "rt", "sync"] }
 tracing = "0.1.30"
 

--- a/input/Cargo.toml
+++ b/input/Cargo.toml
@@ -13,3 +13,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
+evdev = { version = "0.11.4", features = ["tokio"] }
+tokio = { version = "1.16.1", features = ["fs", "rt", "sync"] }
+tracing = "0.1.30"
+
+[features]

--- a/input/src/device.rs
+++ b/input/src/device.rs
@@ -1,0 +1,47 @@
+use std::{ffi::{OsStr, OsString}, path::PathBuf};
+
+use tokio::{sync::mpsc, task::JoinHandle};
+
+pub struct Device {
+    task: JoinHandle<()>,
+    name: OsString,
+}
+
+impl Device {
+    pub fn new(
+        path: PathBuf,
+        mut stream: evdev::EventStream,
+        tx: mpsc::Sender<evdev::InputEvent>,
+    ) -> Self {
+        let name = path
+            .file_name()
+            .expect("Input device should have a file name")
+            .to_os_string();
+        let task = tokio::spawn(async move {
+            loop {
+                match stream.next_event().await {
+                    Ok(event) => {
+                        if let Err(e) = tx.send(event).await {
+                            tracing::warn!(error = %e, "Input event could not be processed");
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(path = %path.display(), error = %e, "Failed to read from input device")
+                    }
+                }
+            }
+        });
+        Self { name, task }
+    }
+
+    pub fn name(&self) -> &OsStr {
+        &self.name
+    }
+}
+
+impl Drop for Device {
+    fn drop(&mut self) {
+        // Stop processing events from this device on drop
+        self.task.abort();
+    }
+}

--- a/input/src/lib.rs
+++ b/input/src/lib.rs
@@ -1,3 +1,95 @@
 mod device;
 use device::Device;
+
+use std::io;
+
+use evdev::InputEvent;
+
+use tokio::{fs, sync::mpsc};
+
+/// The size of the buffer of [`evdev::InputEvent`]s. Sending more events than this at once will
+/// currently stop any more events being sent until at least one is processed.
+///
+/// This applies backpressure to the event stream. However, this may cause issues since Odilia
+/// grabs all keyboard input. If this turns out to be the case, we may need to use an [unbounded
+/// channel][tokio::sync::mpsc::unbounded_channel] instead.
+pub const MAX_INPUT_EVENTS: usize = 1024;
+
+pub struct InputManager {
+    devices: Vec<Device>,
+    rx: mpsc::Receiver<InputEvent>,
 }
+
+impl InputManager {
+/// Initialises the input subsystem, spawning tasks to handle input events.
+pub async fn events() -> io::Result<Self> {
+    let (tx, rx) = mpsc::channel(MAX_INPUT_EVENTS);
+    let devices = open_devices(&tx).await?;
+        Ok(Self { devices, rx })
+}
+
+#[inline]
+pub fn rx_mut(&mut self) -> &mut mpsc::Receiver<InputEvent> {
+    &mut self.rx
+}
+}
+
+    /// Enumerates input devices in `/dev/input`, spawning tasks to handl their
+    /// [`EventStream`][evdev::EventStream]s.
+    ///
+    /// If an error occurs when reading the `/dev/input` directory, the error is returned. If an
+    /// error occurs when opening the device, the error is logged and the device is skipped.
+async fn open_devices(tx: &mpsc::Sender<InputEvent>) -> io::Result<Vec<Device>> {
+        tracing::debug!("Populating input devices from /dev/input");
+
+        let mut devices = Vec::new();
+        let mut dir = fs::read_dir("/dev/input").await?;
+
+        loop {
+            // Get next directory entry
+            let entry = match dir.next_entry().await {
+                Ok(Some(entry)) => entry,
+                Ok(None) => break, // No more entries
+                Err(e) => {
+                    tracing::error!(error = %e, "Failed to read directory entry");
+                    continue;
+                }
+            };
+            let name_os = entry.file_name();
+            // Try to convert to UTF8 (will likely always succeed unless the locale is set
+            // to something uncommon)
+            match name_os.to_str() {
+                Some(name) if name.starts_with("event") => (), // Positive match
+                _ => continue, // We're only interested in /dev/event*
+            }
+            let path = entry.path();
+            // Skip directories (I.E. by-id and by-path)
+            match entry.file_type().await {
+                Ok(t) if !t.is_dir() => (), // Positive match
+                Ok(_) => continue,          // Directory, skip it
+                Err(e) => {
+                    tracing::error!(path = %entry.path().display(), error = %e, "Could not get file type of directory entry");
+                    continue;
+                }
+            }
+            // Open the device
+            tracing::debug!(path = %path.display(), "Opening input device");
+            let dev = match evdev::Device::open(&path) {
+                Ok(d) => d,
+                Err(e) => {
+                    tracing::error!(path = %path.display(), error = %e, "Could not open input device");
+                    continue;
+                }
+            };
+            // Convert to an async stream of events
+            let stream = match dev.into_event_stream() {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::error!(path = %path.display(), error = %e, "Could not create event stream from input device");
+                    continue;
+                }
+            };
+            devices.push(Device::new(path, stream, tx.clone()));
+        }
+        Ok(devices)
+    }

--- a/input/src/lib.rs
+++ b/input/src/lib.rs
@@ -1,8 +1,3 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
+mod device;
+use device::Device;
 }


### PR DESCRIPTION
This implementation of the low-level input subsystem uses the [evdev crate][evdev] to receive and process input events from devices. For each detected device, we:

* Spawn a [task][task] to drive the event stream and handle read errors
    * I would've preferred to trade parallelism in this case for simplicity (less code) and save the overhead of spawning tasks, but I tried multiple approaches to this, and none of them supported dynamically adding and removing streams when devices are connected and disconnected, so instead all device event streams are driven in parallel.
    * If an error occurs when reading events, we log it and then ignore it. This shouldn't be fatal, so there's not much else we can do
* Send the received events down a bounded [MPSC channel][mpsc] so that the higher-level input system can handle them.
    * The channel is bounded so that we have backpressure: if there are too many events, the handler tasks will sleep until some have been processed. Thanks to evdev, if this results in events being dropped in the kernel, we'll get a synchronisation event anyway.

To actually *find* the devices, we first enumerate the entries in `/dev/input`, checking that:

1. The filename is UTF8
2. The name starts with "event" (we're not interested in `mouse*` or the sub-directories)
    * *Why* should we ignore `mouse*`? This is also done in [`evdev::enumerate()`][enumerate].
3. The entry is not a directory
    * This is more of a sanity check than anything
    * Should we instead be checking if the entry is a character device? Are there any evdev nodes that *aren't* char devs?
4. We can open the device, using [`evdev::Device::open()`][device-open]
5. We can get an asynchronous stream of events from the device

After initial population, we then spawn another task, using [inotify][inotify] to watch for created or deleted files. We then appropriately spawn or drop handler tasks for those devices.

* Inotify is Linux specific, can we create an alternative implementation for the BSDs using [kqueue][kqueue]?
* Is there a crate to abstract away the platform-specifics here? I couldn't find one

[evdev]: <https://crates.io/crates/evdev>
[task]: <https://docs.rs/tokio/latest/tokio/task/index.html>
[mpsc]: <https://docs.rs/tokio/latest/tokio/sync/mpsc/index.html>
[enumerate]: <https://docs.rs/evdev/latest/evdev/fn.enumerate.html>
[device-open]: <https://docs.rs/evdev/latest/evdev/struct.Device.html#method.open>
[inotify]: <https://crates.io/crates/inotify>
[kqueue]: <https://crates.io/crates/kqueue>