### PR TITLE
Use the Single Threaded Executor

### DIFF
--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -38,7 +38,7 @@ odilia-input = { path = "../input" }
 odilia-tts = { path = "../tts" }
 pin-utils = "^0.1.0"
 speech-dispatcher = "^0.13.1"
-tokio = { version = "^1.20.0", default-features = false, features = ["sync", "macros", "rt-multi-thread"] }
+tokio = { version = "^1.20.0", default-features = false, features = ["sync", "macros", "rt"] }
 tracing = "^0.1.32"
 tracing-error = "^0.2.0"
 tracing-log = "^0.1.2"

--- a/odilia/src/events/document.rs
+++ b/odilia/src/events/document.rs
@@ -1,16 +1,16 @@
 use zbus::zvariant::ObjectPath;
 
 use atspi::events::Event;
-use crate::state;
+use crate::state::ScreenReaderState;
 
-pub async fn load_complete(event: Event) -> eyre::Result<()> {
+pub async fn load_complete(state: &ScreenReaderState, event: Event) -> eyre::Result<()> {
     let dest = event.sender()?.unwrap();
-    let cache = state::build_cache(
+    let cache = state.build_cache(
         dest, ObjectPath::try_from("/org/a11y/atspi/cache".to_string())?
     ).await?;
     let entire_cache = cache.get_items().await?;
-    let write_by_id_m = state::by_id_write().await;
-    let mut write_by_id = write_by_id_m.lock().await;
+    let write_by_id = &state.cache.by_id_write;
+    let mut write_by_id = write_by_id.lock().await;
     for item in entire_cache {
         // defined in xml/Cache.xml
         let path = item.0.1.to_string();
@@ -26,11 +26,11 @@ pub async fn load_complete(event: Event) -> eyre::Result<()> {
     Ok(())
 }
 
-pub async fn dispatch(event: Event) -> eyre::Result<()> {
+pub async fn dispatch(state: &ScreenReaderState, event: Event) -> eyre::Result<()> {
     // Dispatch based on member
     if let Some(member) = event.member() {
         match member.as_str() {
-            "LoadComplete" => load_complete(event).await?,
+            "LoadComplete" => load_complete(state, event).await?,
             member => tracing::debug!(member, "Ignoring event with unknown member"),
         }
     }

--- a/odilia/src/events/mod.rs
+++ b/odilia/src/events/mod.rs
@@ -1,7 +1,7 @@
 mod object;
 mod document;
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use futures::stream::StreamExt;
 use speech_dispatcher::Priority;
@@ -14,14 +14,14 @@ use atspi::{
     convertable::Convertable,
     events::Event,
 };
-use crate::state;
+use crate::state::ScreenReaderState;
 use odilia_common::{
     events::{Direction, ScreenReaderEvent},
     modes::ScreenReaderMode,
 };
 
-pub async fn structural_navigation(dir: Direction, role: Role) -> zbus::Result<()> {
-    let curr = state::get_accessible_history(0).await?;
+pub async fn structural_navigation(state: &ScreenReaderState, dir: Direction, role: Role) -> zbus::Result<()> {
+    let curr = state.history_item(0).await?;
     let roles = vec![role];
     let attributes = HashMap::new();
     let interfaces = Vec::new();
@@ -37,12 +37,13 @@ pub async fn structural_navigation(dir: Direction, role: Role) -> zbus::Result<(
         let text = next.to_text().await?;
         text.set_caret_offset(0).await?;
     } else {
-        state::say(Priority::Text, "No more headings".to_string()).await;
+        state.say(Priority::Text, "No more headings".to_string()).await;
     }
     Ok(())
 }
 
 pub async fn sr_event(
+    state: Arc<ScreenReaderState>,
     mut sr_events: Receiver<ScreenReaderEvent>,
     mode_channel: Sender<ScreenReaderMode>,
 ) -> zbus::Result<()> {
@@ -54,7 +55,7 @@ pub async fn sr_event(
 
         match sr_event {
             ScreenReaderEvent::StructuralNavigation(dir, role) => {
-                if let Err(e) = structural_navigation(dir, role).await {
+                 if let Err(e) = structural_navigation(&state, dir, role).await {
                     tracing::debug!(error = %e, "There was an error with the structural navigation call.");
                 }
             },
@@ -68,14 +69,14 @@ pub async fn sr_event(
     }
 }
 
-#[tracing::instrument(level = "debug")]
-pub async fn process() {
-    let events = state::get_event_stream().await;
+#[tracing::instrument(level = "debug"i, skip(state))]
+pub async fn process(state: Arc<ScreenReaderState>) {
+    let events = state.atspi.event_stream();
     pin_utils::pin_mut!(events);
     loop {
         match events.next().await {
             Some(Ok(event)) => {
-                if let Err(e) = dispatch(event).await {
+                if let Err(e) = dispatch(&state, event).await {
                     tracing::error!(error = %e, "Could not handle event");
                 }
             },
@@ -84,7 +85,7 @@ pub async fn process() {
     }
 }
 
-async fn dispatch(event: Event) -> eyre::Result<()> {
+async fn dispatch(state: &ScreenReaderState, event: Event) -> eyre::Result<()> {
     // Dispatch based on interface
     if let Some(interface) = event.interface() {
         match interface
@@ -92,8 +93,8 @@ async fn dispatch(event: Event) -> eyre::Result<()> {
             .next()
             .expect("Interface name should contain '.'")
         {
-            "Object" => object::dispatch(event).await?,
-            "Document" => document::dispatch(event).await?,
+            "Object" => object::dispatch(state, event).await?,
+            "Document" => document::dispatch(state, event).await?,
             interface => tracing::debug!(interface, "Ignoring event with unknown interface"),
         }
     }

--- a/odilia/src/events/mod.rs
+++ b/odilia/src/events/mod.rs
@@ -1,7 +1,7 @@
 mod object;
 mod document;
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, rc::Rc};
 
 use futures::stream::StreamExt;
 use speech_dispatcher::Priority;
@@ -43,7 +43,7 @@ pub async fn structural_navigation(state: &ScreenReaderState, dir: Direction, ro
 }
 
 pub async fn sr_event(
-    state: Arc<ScreenReaderState>,
+    state: Rc<ScreenReaderState>,
     mut sr_events: Receiver<ScreenReaderEvent>,
     mode_channel: Sender<ScreenReaderMode>,
 ) -> zbus::Result<()> {
@@ -70,7 +70,7 @@ pub async fn sr_event(
 }
 
 #[tracing::instrument(level = "debug"i, skip(state))]
-pub async fn process(state: Arc<ScreenReaderState>) {
+pub async fn process(state: Rc<ScreenReaderState>) {
     let events = state.atspi.event_stream();
     pin_utils::pin_mut!(events);
     loop {

--- a/odilia/src/events/object.rs
+++ b/odilia/src/events/object.rs
@@ -1,11 +1,12 @@
 use atspi::events::Event;
+use crate::state::ScreenReaderState;
 
-pub async fn dispatch(event: Event) -> eyre::Result<()> {
+pub async fn dispatch(state: &ScreenReaderState, event: Event) -> eyre::Result<()> {
     // Dispatch based on member
     if let Some(member) = event.member() {
         match member.as_str() {
-            "StateChanged" => state_changed::dispatch(event).await?,
-            "TextCaretMoved" => text_caret_moved::dispatch(event).await?,
+            "StateChanged" => state_changed::dispatch(state, event).await?,
+            "TextCaretMoved" => text_caret_moved::dispatch(state, event).await?,
             member => tracing::debug!(member, "Ignoring event with unknown member"),
         }
     }
@@ -13,12 +14,13 @@ pub async fn dispatch(event: Event) -> eyre::Result<()> {
 }
 
 mod text_caret_moved {
-    use crate::state;
-    use atspi::{accessible, events::Event, text};
     use std::cmp::{max, min};
 
-    pub async fn text_cursor_moved(event: Event) -> eyre::Result<()> {
-        let last_caret_pos = state::get_previous_caret_position().await;
+    use atspi::{accessible, events::Event, text};
+    use crate::state::ScreenReaderState;
+
+    pub async fn text_cursor_moved(state: &ScreenReaderState, event: Event) -> eyre::Result<()> {
+        let last_caret_pos = state.previous_caret_position.get();
         let current_caret_pos = event.detail1();
 
         let start = min(last_caret_pos, current_caret_pos);
@@ -34,15 +36,15 @@ mod text_caret_moved {
         } else {
             return Ok(());
         };
-        let conn = state::get_connection().await;
+        let conn = state.connection();
         let text = text::new(&conn.clone(), sender.to_owned(), path.to_owned()).await?;
-        let accessible = accessible::new(&conn.clone(), sender.clone(), path.clone()).await?;
+        let accessible = accessible::new(&conn, sender.clone(), path.clone()).await?;
         let name = text.get_text(start, end).await?;
-        state::update_accessible(sender.to_owned(), path.to_owned()).await;
+        state.update_accessible(sender, path).await;
 
         // this just won't work on the first two accessibles we call. oh well.
-        let latest_accessible = state::get_accessible_history(0).await?;
-        let second_latest_accessible = state::get_accessible_history(0).await?;
+        let latest_accessible = state.history_item(0).await?;
+        let second_latest_accessible = state.history_item(0).await?;
         // if this is the same accessible as previously acted upon, and caret position is 0
         // This will be true if the user has just tabbed into a new accessible.
         if latest_accessible.path() == accessible.path()
@@ -54,19 +56,19 @@ mod text_caret_moved {
             tracing::debug!("Tabbed selection not detected.");
             if !name.is_empty() {
                 tracing::debug!("Speaking normal caret navigation");
-                state::say(speech_dispatcher::Priority::Text, name).await;
+                state.say(speech_dispatcher::Priority::Text, name).await;
             }
         }
 
         // update caret position
-        state::update_caret_position(current_caret_pos).await;
+        state.previous_caret_position.set(current_caret_pos);
         Ok(())
     }
 
-    pub async fn dispatch(event: Event) -> eyre::Result<()> {
+    pub async fn dispatch(state: &ScreenReaderState, event: Event) -> eyre::Result<()> {
         // Dispatch based on kind
         match event.kind() {
-            "" => text_cursor_moved(event).await?,
+            "" => text_cursor_moved(state, event).await?,
             kind => tracing::debug!(kind, "Ignoring event with unknown kind"),
         }
         Ok(())
@@ -74,19 +76,19 @@ mod text_caret_moved {
 } // end of text_caret_moved
 
 mod state_changed {
-    use crate::state;
     use atspi::{accessible, events::Event};
+    use crate::state::ScreenReaderState;
 
-    pub async fn dispatch(event: Event) -> eyre::Result<()> {
+    pub async fn dispatch(state: &ScreenReaderState, event: Event) -> eyre::Result<()> {
         // Dispatch based on kind
         match event.kind() {
-            "focused" => focused(event).await?,
+            "focused" => focused(state, event).await?,
             kind => tracing::debug!(kind, "Ignoring event with unknown kind"),
         }
         Ok(())
     }
 
-    pub async fn focused(event: Event) -> zbus::Result<()> {
+    pub async fn focused(state: &ScreenReaderState, event: Event) -> zbus::Result<()> {
         // Speak the newly focused object
         let path = if let Some(path) = event.path() {
             path.to_owned()
@@ -98,10 +100,10 @@ mod state_changed {
         } else {
             return Ok(());
         };
-        let conn = state::get_connection().await;
+        let conn = state.connection();
         let accessible = accessible::new(&conn.clone(), sender.clone(), path.clone()).await?;
 
-        state::update_accessible(sender.to_owned(), path.to_owned()).await;
+        state.update_accessible(sender.to_owned(), path.to_owned()).await;
 
         let name_fut = accessible.name();
         let description_fut = accessible.description();
@@ -111,7 +113,7 @@ mod state_changed {
             tokio::try_join!(name_fut, description_fut, role_fut, relation_fut)?;
         tracing::debug!("Relations: {:?}", relation);
 
-        state::say(
+        state.say(
             speech_dispatcher::Priority::Text,
             format!("{name}, {role}. {description}"),
         )

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -19,7 +19,7 @@ use odilia_input::{
     keybinds::{add_keybind, update_sr_mode},
 };
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> eyre::Result<()> {
     logging::init();
     let _args = args::parse();

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -4,11 +4,14 @@ mod events;
 mod logging;
 mod state;
 
+use std::sync::Arc;
+
 use eyre::WrapErr;
 use futures::future::FutureExt;
 use tokio::sync::mpsc::channel;
 
 use atspi::accessible::Role;
+use crate::state::ScreenReaderState;
 use odilia_common::{
     events::{Direction, ScreenReaderEvent},
     input::{Key, KeyBinding, Modifiers},
@@ -25,7 +28,7 @@ async fn main() -> eyre::Result<()> {
     let _args = args::parse();
 
     // Initialize state
-    state::init_state().await?;
+    let state = Arc::new(ScreenReaderState::new().await?);
 
     // Add directional structural nav keys
     const S_NAV_BINDINGS: &[(Key, Role)] = &[
@@ -71,16 +74,16 @@ async fn main() -> eyre::Result<()> {
     .await;
 
     // Register events
-    state::register_event("Object:StateChanged:Focused").await?;
-    state::register_event("Object:TextCaretMoved").await?;
-    state::register_event("Document:LoadComplete").await?;
+    state.register_event("Object:StateChanged:Focused").await?;
+    state.register_event("Object:TextCaretMoved").await?;
+    state.register_event("Document:LoadComplete").await?;
 
     // Create and run tasks
     let (mode_change_tx, mode_change_rx) = channel(8); // should maybe be 1? I don't know how it works
     let screen_reader_event_stream = create_keybind_channel();
 
-    let atspi_event_future = tokio::spawn(events::process()).map(|r| r.wrap_err("Could not process at-spi events"));
-    let odilia_event_future = events::sr_event(screen_reader_event_stream, mode_change_tx).map(|r| r.wrap_err("Could not process Odilia events"));
+    let atspi_event_future = tokio::spawn(events::process(Arc::clone(&state))).map(|r| r.wrap_err("Could not process at-spi events"));
+    let odilia_event_future = events::sr_event(Arc::clone(&state), screen_reader_event_stream, mode_change_tx).map(|r| r.wrap_err("Could not process Odilia events"));
     let update_mode_future = tokio::spawn(update_sr_mode(mode_change_rx)).map(|r| r.wrap_err("Could not update mode"));
     tokio::try_join!(atspi_event_future, odilia_event_future, update_mode_future)?;
     Ok(())


### PR DESCRIPTION
[View the Matrix discussion](https://matrix.to/#/!BVPeWFRhpOwtjxKvET:matrix.org/$vnhd45OeK-oEp9FrmAeOduC4s6MNnGr7hZ-s1Lx5geo?via=matrix.org&via=t2bot.io&via=lowerelements.club)

In short, I don't think it makes a lot of sense to use [Tokio](https://tokio.rs)'s multi-threaded executor (`rt-multi` feature) for this project. We're simply not handling enough IO for this to be worth it, and in some cases we pay a premium in synchronisation overhead and *especially* code readability / commplexity. It may also make Odilia less resource heavy in constrained environments, however I'm almost certain the difference will be negligible.

This PR drops the `rt-multi` executor in favor of `rt`, which is single-threaded. It also removes some synchronisation primitives, and gets rid of the global state, both things we no longer need.

## Notes

* State is no longer global, and all previously global functions related to state are now methods.
* For now I decided to keep [`evmap`](https://crates.io/crates/evmap) for the cache, as it still may be useful to allow it to be atomically updated (I.E. other tasks don't see the new cache state until it's finished being updated). If this isn't required however, we can greatly simplify that part of the code, and get rid of a couple of dependencies, by using a [`multimap`](https://crates.io/crates/multimap) instead.
* In some cases, `Mutex<T>`s are still necessary, because of the following scenario:
    1. Task A acquires a resource
    2. Task A hits an `.await` point
    3. Tokio schedules task B, which tries to access the same resource
    4. We usually want task B to suspend and wait for the resource to become available again, which requires an async mutex. For cases where no two tasks should ever access the resource simultaneously, but we still need interior mutability, a `RefCell<T>` can be used instead, as we don't require the task to be suspended should the resource be unavailable.

I'm not too happy about this last point, as getting rid of synchronisation primitives was one of my main motivations for this work, and it turns out we can't in most cases. I'm very much up for discussion about this PR and whether it's worth merging.