### PR TITLE
atspi: Fix states in Cache

### DIFF
--- a/atspi/src/cache.rs
+++ b/atspi/src/cache.rs
@@ -10,6 +10,7 @@
 //! section of the zbus documentation.
 //!
 
+use crate::StateSet;
 use zbus::dbus_proxy;
 
 /// A structure which represents a cache item from AT-SPI.
@@ -35,7 +36,7 @@ use zbus::dbus_proxy;
 /// // more detailed localized name
 /// String,
 /// // states
-/// Vec<u32>
+/// StateSet
 /// ```
 type CacheStruct = (
     (String, zbus::zvariant::OwnedObjectPath), // a11y object reference
@@ -47,7 +48,7 @@ type CacheStruct = (
     String,                                    // localized short names
     u32,                                       // role
     String,                                    // more dtailed localized name
-    Vec<u32>,
+    StateSet,
 ); // states
 
 #[dbus_proxy(interface = "org.a11y.atspi.Cache")]


### PR DESCRIPTION
Follow-up of #25 

While helping investigate #7 I just realized that I forgot to update the `Cache` proxy to use the new `StateSet` type.

Is there a reason why not to create a plain struct with named fields for cached items? We could drop the ugly doc comments for `CacheStruct` then.