### PR TITLE
Fix READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cargo build --release
 # At this point the compiled program is at ./target/release/odilia
 # Optionally, run this to install Odilia to ~/.cargo/bin:
 cargo install --path .
-./setup-permissions.sh
+./scripts/setup-permissions.sh
 ```
 
 ### Udev Permissions
@@ -35,7 +35,7 @@ and redirect events from input devices, such as your keyboard and mouse.
 
 Evdev is normally a privileged interface, since any application that can access it could use it for malicious purposes,
 for example, creating a keylogger. For this reason, to run Odilia, you must give yourself access to evdev. This can be
-done by running the [setup-permissions.sh shell
+done by running the [scripts/setup-permissions.sh shell
 script](https://github.com/odilia-app/odilia/blob/main/setup-permissions.sh) included with Odilia. The script adds some
 udev rules, then creates an odilia group. Any users added to this group and the `input` group will be able to run
 Odilia.

--- a/atspi/README.md
+++ b/atspi/README.md
@@ -1,7 +1,7 @@
 # AT-SPI for Rust
 
 [![crates.io badge](http://meritbadge.herokuapp.com/atspi)](https://crates.io/crates/atspi)
-[![docs.rs badge](https//docs.rs/atspi/badge.svg)](https://docs.rs/atspi)
+[![docs.rs badge](https://docs.rs/atspi/badge.svg)](https://docs.rs/atspi)
 
 Higher level, asynchronous Rust bindings to [AT-SPI2](https://www.freedesktop.org/wiki/Accessibility/AT-SPI2/), using
 [zbus](https://crates.io/crates/zbus).
@@ -37,7 +37,7 @@ atspi = "0.2.1"
 ## Contributing
 
 We love people who add functionality, find bugs, or improve code quality!
-You can clone the respository and make modifications just by `git clone`-ing the repository like so:
+You can clone the repository and make modifications just by `git clone`-ing the repository like so:
 
 ```bash
 $ git clone https://github.com/odilia-app/odilia
@@ -45,7 +45,7 @@ $ cd odilia/atspi
 $ cargo build
 ```
 
-At this time, you need to download our entire `odilia` respository to make modifications to the `atspi` crate.
+At this time, you need to download our entire `odilia` repository to make modifications to the `atspi` crate.
 This will be changed in the future.
 
 ## License


### PR DESCRIPTION
The crates.io badge in the atspi crate is still not working because I didn't want to update the URL as I don't know what you have in mind @TTWNO .

FYI crates.io automatically generates badges. You can find the one for atspi at https://img.shields.io/crates/v/atspi.

So if you just want a regular badge, tell me and I'll update it as part of this PR.