### PR TITLE
Fix config file initialization

### DIFF
--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -1,4 +1,4 @@
-use std::cell::Cell;
+use std::{cell::Cell, fs};
 
 use circular_queue::CircularQueue;
 use eyre::WrapErr;
@@ -50,7 +50,12 @@ impl ScreenReaderState {
         );
         let config_path = xdg_dirs
             .place_config_file("config.toml")
-            .expect("unable to place configuration file. Maybe your system is readonly?")
+            .expect("unable to place configuration file. Maybe your system is readonly?");
+        if !config_path.exists() {
+            fs::copy("config.toml", &config_path)
+                .expect("Unable to copy default config file.");
+        }
+        let config_path = config_path
             .to_str()
             .unwrap()
             .to_owned();


### PR DESCRIPTION
When one starts Odilia for the first time, the configuration file isn't actually copied, therefore the program crashes.

I am sure this is due to a misunderstanding of `xdg::BaseDirectories::place_config_file` which, as its name implies, just makes sur the parent directory on which to place the file is present...