### PR TITLE
atspi: Make `EventBody` generic over serializable types for `kind`

### DIFF
--- a/atspi/src/events/document.rs
+++ b/atspi/src/events/document.rs
@@ -4,25 +4,25 @@ use zbus::dbus_proxy;
 trait Document {
     /// AttributesChanged signal
     #[dbus_proxy(signal)]
-    fn attributes_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn attributes_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// ContentChanged signal
     #[dbus_proxy(signal)]
-    fn content_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn content_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// LoadComplete signal
     #[dbus_proxy(signal)]
-    fn load_complete(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn load_complete(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// LoadStopped signal
     #[dbus_proxy(signal)]
-    fn load_stopped(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn load_stopped(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// PageChanged signal
     #[dbus_proxy(signal)]
-    fn page_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn page_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Reload signal
     #[dbus_proxy(signal)]
-    fn reload(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn reload(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 }

--- a/atspi/src/events/focus.rs
+++ b/atspi/src/events/focus.rs
@@ -4,5 +4,5 @@ use zbus::dbus_proxy;
 trait Focus {
     /// Focus signal
     #[dbus_proxy(signal)]
-    fn focus(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn focus(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 }

--- a/atspi/src/events/keyboard.rs
+++ b/atspi/src/events/keyboard.rs
@@ -4,5 +4,5 @@ use zbus::dbus_proxy;
 trait Keyboard {
     /// Modifiers signal
     #[dbus_proxy(signal)]
-    fn modifiers(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn modifiers(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 }

--- a/atspi/src/events/mouse.rs
+++ b/atspi/src/events/mouse.rs
@@ -4,13 +4,13 @@ use zbus::dbus_proxy;
 trait Mouse {
     /// Abs signal
     #[dbus_proxy(signal)]
-    fn abs(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn abs(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Button signal
     #[dbus_proxy(signal)]
-    fn button(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn button(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Rel signal
     #[dbus_proxy(signal)]
-    fn rel(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn rel(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 }

--- a/atspi/src/events/object.rs
+++ b/atspi/src/events/object.rs
@@ -1,88 +1,89 @@
+use crate::State;
 use zbus::dbus_proxy;
 
 #[dbus_proxy(interface = "org.a11y.atspi.Event.Object")]
 trait Object {
     /// ActiveDescendantChanged signal
     #[dbus_proxy(signal)]
-    fn active_descendant_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn active_descendant_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// AttributesChanged signal
     #[dbus_proxy(signal)]
-    fn attributes_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn attributes_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// BoundsChanged signal
     #[dbus_proxy(signal)]
-    fn bounds_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn bounds_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// ChildrenChanged signal
     #[dbus_proxy(signal)]
-    fn children_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn children_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// ColumnDeleted signal
     #[dbus_proxy(signal)]
-    fn column_deleted(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn column_deleted(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// ColumnInserted signal
     #[dbus_proxy(signal)]
-    fn column_inserted(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn column_inserted(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// ColumnReordered signal
     #[dbus_proxy(signal)]
-    fn column_reordered(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn column_reordered(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// LinkSelected signal
     #[dbus_proxy(signal)]
-    fn link_selected(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn link_selected(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// ModelChanged signal
     #[dbus_proxy(signal)]
-    fn model_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn model_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// PropertyChange signal
     #[dbus_proxy(signal)]
-    fn property_change(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn property_change(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// RowDeleted signal
     #[dbus_proxy(signal)]
-    fn row_deleted(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn row_deleted(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// RowInserted signal
     #[dbus_proxy(signal)]
-    fn row_inserted(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn row_inserted(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// RowReordered signal
     #[dbus_proxy(signal)]
-    fn row_reordered(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn row_reordered(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// SelectionChanged signal
     #[dbus_proxy(signal)]
-    fn selection_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn selection_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// StateChanged signal
     #[dbus_proxy(signal)]
-    fn state_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn state_changed(&self, event: super::EventBody<'_, State>) -> zbus::Result<()>;
 
     /// TextAttributesChanged signal
     #[dbus_proxy(signal)]
-    fn text_attributes_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn text_attributes_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// TextBoundsChanged signal
     #[dbus_proxy(signal)]
-    fn text_bounds_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn text_bounds_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// TextCaretMoved signal
     #[dbus_proxy(signal)]
-    fn text_caret_moved(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn text_caret_moved(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// TextChanged signal
     #[dbus_proxy(signal)]
-    fn text_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn text_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// TextSelectionChanged signal
     #[dbus_proxy(signal)]
-    fn text_selection_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn text_selection_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// VisibleDataChanged signal
     #[dbus_proxy(signal)]
-    fn visible_data_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn visible_data_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 }

--- a/atspi/src/events/terminal.rs
+++ b/atspi/src/events/terminal.rs
@@ -4,21 +4,21 @@ use zbus::dbus_proxy;
 trait Terminal {
     /// ApplicationChanged signal
     #[dbus_proxy(signal)]
-    fn application_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn application_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// CharwidthChanged signal
     #[dbus_proxy(signal)]
-    fn charwidth_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn charwidth_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// ColumncountChanged signal
     #[dbus_proxy(signal)]
-    fn columncount_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn columncount_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// LineChanged signal
     #[dbus_proxy(signal)]
-    fn line_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn line_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// LinecountChanged signal
     #[dbus_proxy(signal)]
-    fn linecount_changed(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn linecount_changed(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 }

--- a/atspi/src/events/window.rs
+++ b/atspi/src/events/window.rs
@@ -4,77 +4,77 @@ use zbus::dbus_proxy;
 trait Window {
     /// Activate signal
     #[dbus_proxy(signal)]
-    fn activate(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn activate(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Close signal
     #[dbus_proxy(signal)]
-    fn close(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn close(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Create signal
     #[dbus_proxy(signal)]
-    fn create(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn create(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Deactivate signal
     #[dbus_proxy(signal)]
-    fn deactivate(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn deactivate(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// DesktopCreate signal
     #[dbus_proxy(signal)]
-    fn desktop_create(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn desktop_create(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// DesktopDestroy signal
     #[dbus_proxy(signal)]
-    fn desktop_destroy(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn desktop_destroy(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Destroy signal
     #[dbus_proxy(signal)]
-    fn destroy(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn destroy(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Lower signal
     #[dbus_proxy(signal)]
-    fn lower(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn lower(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Maximize signal
     #[dbus_proxy(signal)]
-    fn maximize(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn maximize(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Minimize signal
     #[dbus_proxy(signal)]
-    fn minimize(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn minimize(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Move signal
     #[dbus_proxy(signal)]
-    fn move_(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn move_(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// PropertyChange signal
     #[dbus_proxy(signal)]
-    fn property_change(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn property_change(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Raise signal
     #[dbus_proxy(signal)]
-    fn raise(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn raise(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Reparent signal
     #[dbus_proxy(signal)]
-    fn reparent(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn reparent(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Resize signal
     #[dbus_proxy(signal)]
-    fn resize(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn resize(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Restore signal
     #[dbus_proxy(signal)]
-    fn restore(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn restore(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Restyle signal
     #[dbus_proxy(signal)]
-    fn restyle(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn restyle(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// Shade signal
     #[dbus_proxy(signal)]
-    fn shade(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn shade(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 
     /// uUshade signal
     #[dbus_proxy(signal)]
-    fn u_ushade(&self, event: super::EventBody<'_>) -> zbus::Result<()>;
+    fn u_ushade(&self, event: super::EventBody<'_, &str>) -> zbus::Result<()>;
 }

--- a/atspi/src/state.rs
+++ b/atspi/src/state.rs
@@ -1,7 +1,8 @@
 use enumflags2::{bitflags, BitFlag, BitFlags, FromBitsError};
 use serde::{
-    de::{self, Deserialize, Deserializer, Visitor},
-    ser::{Serialize, SerializeSeq, Serializer},
+    de::{self, Deserializer, Visitor},
+    ser::{SerializeSeq, Serializer},
+    Deserialize, Serialize,
 };
 use std::fmt;
 use zbus::zvariant::{Signature, Type};
@@ -10,7 +11,8 @@ use zbus::zvariant::{Signature, Type};
 /// an [`crate::accessible::AccessibleProxy`] object can assume.
 #[bitflags]
 #[repr(u64)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub enum State {
     /// Indicates an invalid state - probably an error condition.
     Invalid,


### PR DESCRIPTION
I still haven't figured out the best way forward for this, but at least now it's possible to serialize events holding a `kind` which type is something other than `&str`. At least I'll be able to take advantage of this for AccessKit.

- Added serde support to the `State` type.
- Rearranged `EventBodyQT` (I don't see why we would need a borrowing version of this type, it's kind of a bug in Qt so you wouldn't want anybody to use it on the server-side).
- Updated signals to use `EventBody<&str>` (except object's `state_changed` which now takes `EventBody<State>`).

Hopefully this can spark ideas on how to better type-check these event related structs.