### PR TITLE
atspi: impl `BitAnd` for `InterfaceSet`

### DIFF
--- a/atspi/src/interfaces.rs
+++ b/atspi/src/interfaces.rs
@@ -203,6 +203,14 @@ impl From<Interface> for InterfaceSet {
     }
 }
 
+impl std::ops::BitAnd for InterfaceSet {
+    type Output = InterfaceSet;
+
+    fn bitand(self, other: Self) -> Self::Output {
+        InterfaceSet(self.0 & other.0)
+    }
+}
+
 impl std::ops::BitXor for InterfaceSet {
     type Output = InterfaceSet;
 


### PR DESCRIPTION
I need this to easily compute which interfaces an object may have gained or lost between tree updates.

See [here](https://github.com/DataTriny/accesskit/blob/8b9dd35b707ac67c33f0c9f219649d418cbe5943/platforms/linux/src/adapter.rs#L136) for actual use.