### PR TITLE
atspi: Add default path and service name to SocketProxy

### DIFF
--- a/atspi/src/socket.rs
+++ b/atspi/src/socket.rs
@@ -12,7 +12,11 @@
 
 use zbus::dbus_proxy;
 
-#[dbus_proxy(interface = "org.a11y.atspi.Socket")]
+#[dbus_proxy(
+    interface = "org.a11y.atspi.Socket",
+    default_path = "/org/a11y/atspi/accessible/root",
+    default_service = "org.a11y.atspi.Registry",
+)]
 trait Socket {
     /// Embed method
     fn embed(


### PR DESCRIPTION
It took me ages to figure out why my test app was no longer being registered by the AT-SPI registry since I switched to the `atspi` crate. I forgot that I had set the `default_path` and `default_service` attributes on my `SocketProxy` implementation. So I would suggest to add these back here too.

I am aware that `Socket` can also be implemented by providers, but I think it makes sense to have it pointing towards the registry by default. You aren't supposed to know where it is located (it's not documented anywhere afterall) unless you're an AT-SPI nerd!