### PR TITLE
[atspi] Comment in global attribute macro confuses ra / clippy

### DIFF
--- a/atspi/src/lib.rs
+++ b/atspi/src/lib.rs
@@ -1,10 +1,5 @@
-#![deny(
-  clippy::all,
-  clippy::pedantic,
-  clippy::cargo,
-  //missing_docs,
-  unsafe_code
-)]
+#![deny(clippy::all, clippy::pedantic, clippy::cargo, unsafe_code)]
+// #![deny(clippy::missing_docs)]
 
 pub mod accessible;
 pub mod action;


### PR DESCRIPTION
This moves the comment outside of the macro to restore its intended behaviour.
