### PR TITLE
fix filename typo and add sudo prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cargo build --release
 # At this point the compiled program is at ./target/release/odilia
 # Optionally, run this to install Odilia to ~/.cargo/bin:
 cargo install --path .
-./scripts/setup-permissions.sh
+sudo ./scripts/setup_permissions.sh
 ```
 
 ### Udev Permissions


### PR DESCRIPTION
setup-permissions.sh should be setup_permissions.sh and it need root permission to run the script.