### PR TITLE
Set `IsEnabled` property on start-up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ pre-release-hook = ["cargo", "fmt"]
 dependent-version = "upgrade"
 
 [workspace.dependencies]
-atspi = { version = "^0.3.7", default-features = false, features = ["tokio"] }
+atspi = { version = "0.3.9", default-features = false, features = ["tokio"] }
 eyre = "0.6.8"
 nix = "0.25.0"
 serde_json = "1.0.89"


### PR DESCRIPTION
This adds a call to `atspi::set_session_accessibility`.

Applications may monitor `IsEnabled`  from `org.a11y.Status` on the session bus to dynamically support AT-SPI2 functionality. This makes sure those which do, know they should now expose their AT-SPI2 interfaces on the bus.