### PR TITLE
Address a few inconsistencies in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,36 @@ Try it out! See if it works for you!
 ## Building
 
 To build odilia:
+Copy paste the following on your command line to clone, build and install Odilia on your behalf in `~/.cargo/bin`,
 
-```sh
-git clone https://github.com/odilia-app/odilia
-cd odilia
-cargo build --release
-# At this point the compiled program is at ./target/release/odilia
-# Optionally, run this to install Odilia to ~/.cargo/bin:
-cargo install --path .
+```shell
+git clone https://github.com/odilia-app/odilia  && \
+cd odilia && \
+cargo build --release && \
+cargo install --path odilia
+```
+
+Odilia requires `uinput` access, the kernel's provisioning to emulate input devices. Furthermore, Odilia requires the user to be in the 'odilia' and 'input' groups.
+Lastly Odilia requires appropriate `evdev` rules, For more information see also:  [Udev Permissions](Sudev-permissions).
+This script will enable these on your behalf:
+
+```shell
 sudo ./scripts/setup_permissions.sh
-sudo ./scripts/install_configs.sh
-# You will also want to compile sohkd.
-cd sohkd
-cargo build --release
+```
+
+This script will populate `/etc/odilia` with several configuration files.
+
+```shell
+sudo ./scripts/install_configs.sh`
+```
+
+You will also want to compile and install sohkd.
+(Copy and paste the following on your command line. )
+
+```shell
+cd sohkd && \
+cargo build && \
+cp ../target/debug/sohkd ~/.cargo/bin/
 ```
 
 ### Udev Permissions
@@ -49,9 +66,11 @@ Odilia.
 To run Odilia, you should use our script.
 This will ask for your password (if you have sudo permissions) and then launch both Odilia and the key daemon in quiet mode.
 
-```bash
-./scripts/odilia
-# in another terminal
+The following assumes you are in the workspace root. If you are still in `sohkd`:  ``shell cd .. ```
+(Copy and paste the following on your command line. )
+
+```shell
+./scripts/odilia & \
 ./scripts/debug_start_sohkd.sh
 ```
 
@@ -61,13 +80,13 @@ You can find us at the following places:
 
 * [Discord](https://discord.gg/RVpRb9nS6K)
 * IRC: irc.libera.chat
-	* #odilia-dev (development)
-	* #odilia (general)
-	* #odilia-offtopic (off-topic)
+  * #odilia-dev (development)
+  * #odilia (general)
+  * #odilia-offtopic (off-topic)
 * Matrix: stealthy.club
-	* #odilia-dev (development)
-	* #odilia (general)
-	* #odilia-offtopic (off-topic)
+  * #odilia-dev (development)
+  * #odilia (general)
+  * #odilia-offtopic (off-topic)
 
 ## Contributing
 

--- a/scripts/debug_start_sohkd.sh
+++ b/scripts/debug_start_sohkd.sh
@@ -1,1 +1,1 @@
-pkttyagent -p $(echo $$) | pkexec ./target/debug/sohkd --debug --config /etc/odilia/sohkdrc
+pkttyagent -p $(echo $$) | pkexec sohkd --debug --config /etc/odilia/sohkdrc


### PR DESCRIPTION
This simplifies installation and running Odilia (atleast somewhat) and aims to address #78 at least in part.

This:
- Changes cloning, compiling and installing to one command. Fixes: install path.
- Changes markdown on shell blocks all \`\`\`shell, which unifies the shell markdown 'lexers'.
- Changes compilation of `sohkd` to debug and copies the binary to `~/.cargo/biin`
- Modifies `debug_start_sohkd.sh` accordingly.
- Explains a bit more what it is we aim to do.

The result is one can come to the README and just copy-and-paste the shell blocks, after which Odilia should run.

I hope this helps!