### PR TITLE
Work on improving instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ cargo build && \
 cp ../target/debug/sohkd ~/.cargo/bin/
 ```
 
+### Prerequisite
+
+Perhaps unnecessarily, but you will need to have `speech-dispatcher` installed and running before you can start Odilia.
+
 ### Udev Permissions
 
 Odilia uses the Linux kernel's [evdev interface](https://freedesktop.org/software/libevdev/doc/latest/) to listen for
@@ -66,11 +70,13 @@ Odilia.
 To run Odilia, you should use our script.
 This will ask for your password (if you have sudo permissions) and then launch both Odilia and the key daemon in quiet mode.
 
-The following assumes you are in the workspace root. If you are still in `sohkd`:  ``shell cd .. ```
-(Copy and paste the following on your command line. )
+```shell
+./scripts/odilia
+```
+
+Then launch the hotkey-deamon:
 
 ```shell
-./scripts/odilia & \
 ./scripts/debug_start_sohkd.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,19 +17,36 @@ Try it out! See if it works for you!
 ## Building
 
 To build odilia:
+Copy paste the following on your command line to clone, build and install Odilia on your behalf in `~/.cargo/bin`,
 
-```sh
-git clone https://github.com/odilia-app/odilia
-cd odilia
-cargo build --release
-# At this point the compiled program is at ./target/release/odilia
-# Optionally, run this to install Odilia to ~/.cargo/bin:
-cargo install --path .
+```shell
+git clone https://github.com/odilia-app/odilia  && \
+cd odilia && \
+cargo build --release && \
+cargo install --path odilia
+```
+
+Odilia requires `uinput` access, the kernel's provisioning to emulate input devices. Furthermore, Odilia requires the user to be in the 'odilia' and 'input' groups.
+Lastly Odilia requires appropriate `evdev` rules, For more information see also:  [Udev Permissions](Sudev-permissions).
+This script will enable these on your behalf:
+
+```shell
 sudo ./scripts/setup_permissions.sh
-sudo ./scripts/install_configs.sh
-# You will also want to compile sohkd.
-cd sohkd
-cargo build --release
+```
+
+This script will populate `/etc/odilia` with several configuration files.
+
+```shell
+sudo ./scripts/install_configs.sh`
+```
+
+You will also want to compile and install sohkd.
+(Copy and paste the following on your command line. )
+
+```shell
+cd sohkd && \
+cargo build && \
+cp ../target/debug/sohkd ~/.cargo/bin/
 ```
 
 ### Udev Permissions
@@ -49,9 +66,11 @@ Odilia.
 To run Odilia, you should use our script.
 This will ask for your password (if you have sudo permissions) and then launch both Odilia and the key daemon in quiet mode.
 
-```bash
-./scripts/odilia
-# in another terminal
+The following assumes you are in the workspace root. If you are still in `sohkd`:  ``shell cd .. ```
+(Copy and paste the following on your command line. )
+
+```shell
+./scripts/odilia & \
 ./scripts/debug_start_sohkd.sh
 ```
 
@@ -61,13 +80,13 @@ You can find us at the following places:
 
 * [Discord](https://discord.gg/RVpRb9nS6K)
 * IRC: irc.libera.chat
-	* #odilia-dev (development)
-	* #odilia (general)
-	* #odilia-offtopic (off-topic)
+  * #odilia-dev (development)
+  * #odilia (general)
+  * #odilia-offtopic (off-topic)
 * Matrix: stealthy.club
-	* #odilia-dev (development)
-	* #odilia (general)
-	* #odilia-offtopic (off-topic)
+  * #odilia-dev (development)
+  * #odilia (general)
+  * #odilia-offtopic (off-topic)
 
 ## Contributing
 

--- a/scripts/debug_start_sohkd.sh
+++ b/scripts/debug_start_sohkd.sh
@@ -1,1 +1,1 @@
-pkttyagent -p $(echo $$) | pkexec sohkd --debug --config /etc/odilia/sohkdrc
+pkttyagent -p $(echo $$) | pkexec env XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR  ~/.cargo/bin/sohkd --debug --config /etc/odilia/sohkdrc

--- a/scripts/debug_start_sohkd.sh
+++ b/scripts/debug_start_sohkd.sh
@@ -1,1 +1,1 @@
-pkttyagent -p $(echo $$) | pkexec ./target/debug/sohkd --debug --config /etc/odilia/sohkdrc
+pkttyagent -p $(echo $$) | pkexec sohkd --debug --config /etc/odilia/sohkdrc

--- a/scripts/odilia
+++ b/scripts/odilia
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-RUST_LOG=none ./target/release/odilia
+RUST_LOG=none ~/.cargo/bin/odilia


### PR DESCRIPTION
Two commits address #78 to some extent. 
Sumary:

Commit 4be1247
Reduce number of steps to install:
- Changes cloning, compiling and installing to one command.
    Fixes: install path.

Makes sure the instructions and the script assume the same:
- Changes compilation of `sohkd` to debug and copies the binary to `~/.cargo/biin`
- Modifies `debug_start_sohkd.sh` accordingly.
 
- Explains a bit more what it is we do.

Commit 1fa640b
Makes less assumptions on what the users install base looks like:
 - Adds 'Prerequisite' notice in the README

 Unclutter terminal:
 - Reverts merged-launch of `Odilia` and `sohkd`.

 Makes launching `sohkd` independent of the pwd:
 - Adds `XDG_RUNTIME_DIR` and use path `~/.cargo/bin` to launch `sohkd`.

 Makes launching `Odilia` independent of the pwd:
  - Use `~/.cargo/bin` to launch `Odilia`.

