### PR TITLE
Towards a thread-safe implementation of independent event tasks. This…

### DIFF
--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -100,7 +100,7 @@ impl<'a> TryFrom<&AccessibleProxy<'a>> for AccessiblePrimitive {
     };
     Ok(AccessiblePrimitive {
       id,
-      sender: sender.into(),
+      sender
     })
   }
 }
@@ -115,7 +115,7 @@ impl<'a> TryFrom<AccessibleProxy<'a>> for AccessiblePrimitive {
     };
     Ok(AccessiblePrimitive {
       id,
-      sender: sender.into(),
+      sender
     })
   }
 }

--- a/odilia/src/events/document.rs
+++ b/odilia/src/events/document.rs
@@ -1,6 +1,3 @@
-use zbus::{
-	names::UniqueName,
-};
 use odilia_cache::CacheItem;
 
 use crate::state::ScreenReaderState;
@@ -12,8 +9,7 @@ use atspi::{
 
 pub async fn load_complete(state: &ScreenReaderState, event: &LoadCompleteEvent) -> eyre::Result<()> {
 	let sender = event.sender()?.unwrap();
-	let cache = state.build_cache(
-		UniqueName::try_from(sender.clone())?).await?;
+	let cache = state.build_cache(sender.clone()).await?;
 	let entire_cache = cache.get_items().await?;
 	let mut cache_items = Vec::new();
 	for item in entire_cache {

--- a/odilia/src/events/object.rs
+++ b/odilia/src/events/object.rs
@@ -46,6 +46,7 @@ mod children_changed {
 }
 
 mod text_caret_moved {
+  use std::sync::atomic::Ordering;
 	use crate::state::ScreenReaderState;
 	use atspi::{convertable::Convertable, identify::object::TextCaretMovedEvent, signify::Signified};
 	use ssip_client::Priority;
@@ -68,7 +69,7 @@ mod text_caret_moved {
 		// likewise when getting the second-most recently focused accessible; we need the second-most recent accessible because it is possible that a tab navigation happened, which focused something before (or after) the caret moved events gets called, meaning the second-most recent accessible may be the only different accessible.
 		// if the accessible is focused before the event happens, the last_accessible variable will be the same as current_accessible.
 		// if the accessible is focused after the event happens, then the last_accessible will be different
-		let previous_caret_pos = state.previous_caret_position.get();
+		let previous_caret_pos = state.previous_caret_position.load(Ordering::Relaxed);
 		let current_accessible = state.new_accessible(event).await?;
 		// if we know that the previous caret position was not 0, and the current and previous accessibles are the same, we know that this is NOT a tab navigation.
 		if previous_caret_pos != 0 &&

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, fs};
+use std::{cell::Cell, fs, sync::atomic::AtomicI32};
 
 use circular_queue::CircularQueue;
 use eyre::WrapErr;
@@ -25,7 +25,7 @@ pub struct ScreenReaderState {
 	pub dbus: DBusProxy<'static>,
 	pub ssip: Sender<SSIPRequest>,
 	pub config: ApplicationConfig,
-	pub previous_caret_position: Cell<i32>,
+	pub previous_caret_position: AtomicI32,
 	pub mode: Mutex<ScreenReaderMode>,
 	pub granularity: Mutex<Granularity>,
 	pub accessible_history: Mutex<CircularQueue<AccessiblePrimitive>>,
@@ -62,7 +62,7 @@ impl ScreenReaderState {
 			.wrap_err("unable to load configuration file")?;
 		tracing::debug!("configuration loaded successfully");
 
-		let previous_caret_position = Cell::new(0);
+		let previous_caret_position = AtomicI32::new(0);
 		let accessible_history = Mutex::new(CircularQueue::with_capacity(16));
 		let event_history = Mutex::new(CircularQueue::with_capacity(16));
 		let cache = Cache::new();

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, fs, sync::atomic::AtomicI32};
+use std::{fs, sync::atomic::AtomicI32};
 
 use circular_queue::CircularQueue;
 use eyre::WrapErr;


### PR DESCRIPTION
… will improve issues with deadlocking, and it will add the ability to use .await freely on long-awaiting tasks like calling zbus methods without blocking the entite event task.

I have seen anything from <100 microseconds (1/10,000 of a second) and over 100 milliseconds (1/10 of a second). And I think it's worth allowing those awaits to take as long as they need and just run them across tasks.

Still in progress and doesn't compile. Basically need to put ScreenReaderState in an Arc.