### PR TITLE
Fix missing atspi dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ pre-release-hook = ["cargo", "fmt"]
 dependent-version = "upgrade"
 
 [workspace.dependencies]
-atspi = { version = "0.10.0", git = "https://github.com/odilia-app/atspi", branch = "fix-name-of-text-changed-parameter", default-features = false, features = ["tokio"] }
+atspi = { git = "https://github.com/odilia-app/atspi", branch = "main", default-features = false, features = ["tokio"] }
 eyre = "0.6.8"
 nix = "0.25.0"
 serde_json = "1.0.89"


### PR DESCRIPTION
When https://github.com/odilia-app/atspi/pull/51 was merged, the `fix-name-of-text-changed-parameter` branch was deleted. So, currently on `main`, `odilia` fails to build:

```
❯ cargo build

error: failed to get `atspi` as a dependency of package `odilia-cache v0.1.0 (/home/sam/code/odilia/cache)`

Caused by:
  failed to load source for dependency `atspi`

Caused by:
  Unable to update https://github.com/odilia-app/atspi?branch=fix-name-of-text-changed-parameter

Caused by:
  failed to find branch `fix-name-of-text-changed-parameter`

Caused by:
  cannot locate remote-tracking branch 'origin/fix-name-of-text-changed-parameter'; class=Reference (4); code=NotFound (-3)
```

I imagine you'll want to get a release out for `atspi` and go back to tracking by version, but in the meantime, this will fix the build.