### PR TITLE
Cache referencing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,7 @@ dependencies = [
  "circular-queue",
  "eyre",
  "futures",
+ "lazy_static",
  "odilia-cache",
  "odilia-common",
  "odilia-input",
@@ -972,6 +973,7 @@ dependencies = [
 name = "odilia-cache"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "atspi",
  "criterion",
  "odilia-common",

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -12,6 +12,7 @@ serde = "1.0.147"
 tokio.workspace = true
 tracing.workspace = true
 zbus.workspace = true
+async-trait = "0.1.64"
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -12,12 +12,32 @@ pub enum OdiliaError {
 	Zbus(zbus::Error),
 	ZbusFdo(zbus::fdo::Error),
 	Zvariant(zbus::zvariant::Error),
+	Cache(CacheError),
 	InfallibleConversion(std::convert::Infallible),
 }
+#[derive(Debug)]
+pub enum CacheError {
+	NotAvailable,
+	NoItem,
+}
+impl std::fmt::Display for CacheError {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::NotAvailable => f.write_str("The cache has been dropped from memory. This never happens under normal circumstances, and should never happen. Please send a detailed bug report if this ever happens."),
+			Self::NoItem => f.write_str("No item in cache found."),
+		}
+	}
+}
+impl std::error::Error for CacheError {}
 impl Error for OdiliaError {}
 impl From<zbus::fdo::Error> for OdiliaError {
 	fn from(spe: zbus::fdo::Error) -> Self {
 		Self::ZbusFdo(spe)
+	}
+}
+impl From<CacheError> for OdiliaError {
+	fn from(cache_error: CacheError) -> Self {
+		Self::Cache(cache_error)
 	}
 }
 impl From<zbus::Error> for OdiliaError {

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -45,6 +45,9 @@ tracing.workspace = true
 xdg = "2.4.1"
 zbus.workspace = true
 
+[dev-dependencies]
+lazy_static = "1.4.0"
+
 [features]
 
 #[build-dependencies]


### PR DESCRIPTION
This PR is made to reference either the `Cache` struct itself, or individual `CacheItem`s from within the `CacheItem` struct.

The best, naive, simple way to do this is to just store a `Weak<Cache>` in each `CacheItem`. The only issue is the `Cache::get_or_create()` function, that would need an `Arc<Cache>` not the available `Arc<&Cache>`.

I really don't want to have to deal with lifetimes in `CacheItem`s if I can avoid it, but I suspect we'll eventually need it anyway, so if the acceptable answer is `cache: Weak<&'a Cache>`, that's fine, but I want to try not doing that in the meantime.
