### PR TITLE
readme.md: Fix spelling of 'environment'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cargo install --path .
 
 ## Running
 
-To run Odilia, you should use our script, this will suppress log output and add environemnt variables that make using the screen reader easier.
+To run Odilia, you should use our script. This will suppress log output and add environment variables that make using the screen reader easier.
 
 ```shell
 ./scripts/odilia


### PR DESCRIPTION
Just found this typo, too.