### PR TITLE
add clippi warning for print statements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           command: clippy
           # "-- -D warnings" will make the job fail if their are clippy warnings
-          args: --workspace --no-deps -- -D warnings
+          args: --workspace --no-deps -- -D warnings -W clippy::print_stdout
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "odilia"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "atspi",
  "circular-queue",


### PR DESCRIPTION
From now on, any code that contains the print! and println! macros will not be able to be merged because CI would fail on clippy lints, to fix the issue, use debug! or info! in stead. This is very good because sometimes we accidentally put one of those in a function or something, since we're used to it and it entered in muscle memory. While a local lint would also be nice through something like a clippy.toml file so lsp errors on us while building the code, that's the best we got for now.  
note: it's possible that CI will fail on this, but if so, it's not the pr that's failing, it's the code in main that contains a print statement. If that happens, conversation is open, should we fix it here, or in a separate pr?