### PR TITLE
Update AT-SPI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -123,7 +123,7 @@ dependencies = [
  "futures-lite",
  "rustix",
  "signal-hook",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -211,33 +211,54 @@ checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 [[package]]
 name = "atspi"
 version = "0.16.0"
-source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#8f254d3e30024574ff1ab1d5cd9c46c44f8fe8ce"
+source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#d553c4af9a6d1807fb529d5f191ac37128f8e757"
 dependencies = [
- "async-trait",
- "atspi-macros",
- "atspi-types",
- "enumflags2",
- "serde",
- "static_assertions",
- "zbus",
+ "atspi-client",
+ "atspi-common",
+ "atspi-connection",
+ "atspi-proxies",
 ]
 
 [[package]]
 name = "atspi-client"
 version = "0.1.0"
-source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#8f254d3e30024574ff1ab1d5cd9c46c44f8fe8ce"
+source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#d553c4af9a6d1807fb529d5f191ac37128f8e757"
 dependencies = [
- "atspi",
- "atspi-types",
+ "async-trait",
+ "atspi-common",
+ "atspi-proxies",
+ "static_assertions",
+ "zbus",
+]
+
+[[package]]
+name = "atspi-common"
+version = "0.1.0"
+source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#d553c4af9a6d1807fb529d5f191ac37128f8e757"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "atspi-connection"
+version = "0.1.0"
+source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#d553c4af9a6d1807fb529d5f191ac37128f8e757"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
  "futures-lite",
- "tracing",
  "zbus",
 ]
 
 [[package]]
 name = "atspi-macros"
 version = "0.4.0"
-source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#8f254d3e30024574ff1ab1d5cd9c46c44f8fe8ce"
+source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#d553c4af9a6d1807fb529d5f191ac37128f8e757"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -250,17 +271,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "atspi-types"
+name = "atspi-proxies"
 version = "0.1.0"
-source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#8f254d3e30024574ff1ab1d5cd9c46c44f8fe8ce"
+source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#d553c4af9a6d1807fb529d5f191ac37128f8e757"
 dependencies = [
+ "async-trait",
+ "atspi-common",
+ "atspi-macros",
  "enumflags2",
  "serde",
- "static_assertions",
- "tokio-stream",
  "zbus",
- "zbus_names",
- "zvariant",
 ]
 
 [[package]]
@@ -488,22 +508,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.8.0",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
@@ -607,7 +627,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -745,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -820,7 +840,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -856,7 +876,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -876,9 +896,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -900,9 +920,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "linux-raw-sys"
@@ -912,9 +932,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -922,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 dependencies = [
  "value-bag",
 ]
@@ -955,23 +975,22 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1032,7 +1051,9 @@ version = "0.1.4"
 dependencies = [
  "atspi",
  "atspi-client",
- "atspi-types",
+ "atspi-common",
+ "atspi-connection",
+ "atspi-proxies",
  "circular-queue",
  "eyre",
  "futures",
@@ -1062,7 +1083,8 @@ dependencies = [
  "async-trait",
  "atspi",
  "atspi-client",
- "atspi-types",
+ "atspi-common",
+ "atspi-proxies",
  "criterion",
  "dashmap",
  "fxhash",
@@ -1082,7 +1104,7 @@ name = "odilia-common"
 version = "0.3.0"
 dependencies = [
  "atspi",
- "atspi-types",
+ "atspi-common",
  "bitflags",
  "serde",
  "serde_plain",
@@ -1119,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "oorandom"
@@ -1141,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.5.0"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
+checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "overload"
@@ -1169,15 +1191,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1233,7 +1255,7 @@ dependencies = [
  "libc",
  "log",
  "pin-project-lite",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1254,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -1353,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1385,16 +1407,16 @@ checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1426,9 +1448,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
@@ -1447,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1641,15 +1663,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1720,7 +1743,7 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1922,9 +1945,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1932,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
@@ -1947,9 +1970,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.36"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1959,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1969,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1982,15 +2005,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2029,35 +2052,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2066,20 +2065,14 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2089,21 +2082,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2113,21 +2094,9 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2137,21 +2106,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2189,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8f380ae16a37b30e6a2cf67040608071384b1450c189e61bea3ff57cde922d"
+checksum = "52839dc911083a8ef63efa4d039d1f58b5e409f923e44c80828f206f66e5541c"
 
 [[package]]
 name = "zbus"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -199,7 +199,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -211,7 +211,6 @@ checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 [[package]]
 name = "atspi"
 version = "0.16.0"
-source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#a7871c5f31c20a131563e5c0018bc2542a981e43"
 dependencies = [
  "async-trait",
  "atspi-macros",
@@ -225,7 +224,6 @@ dependencies = [
 [[package]]
 name = "atspi-client"
 version = "0.1.0"
-source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#a7871c5f31c20a131563e5c0018bc2542a981e43"
 dependencies = [
  "atspi",
  "atspi-types",
@@ -237,7 +235,6 @@ dependencies = [
 [[package]]
 name = "atspi-macros"
 version = "0.4.0"
-source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#a7871c5f31c20a131563e5c0018bc2542a981e43"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -252,7 +249,6 @@ dependencies = [
 [[package]]
 name = "atspi-types"
 version = "0.1.0"
-source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#a7871c5f31c20a131563e5c0018bc2542a981e43"
 dependencies = [
  "enumflags2",
  "serde",
@@ -519,16 +515,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "dashmap"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,7 +592,7 @@ checksum = "5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -932,11 +918,10 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 dependencies = [
- "cfg-if",
  "value-bag",
 ]
 
@@ -1042,6 +1027,8 @@ name = "odilia"
 version = "0.1.4"
 dependencies = [
  "atspi",
+ "atspi-client",
+ "atspi-types",
  "circular-queue",
  "eyre",
  "futures",
@@ -1071,6 +1058,7 @@ dependencies = [
  "async-trait",
  "atspi",
  "atspi-client",
+ "atspi-types",
  "criterion",
  "dashmap",
  "fxhash",
@@ -1090,6 +1078,7 @@ name = "odilia-common"
 version = "0.3.0"
 dependencies = [
  "atspi",
+ "atspi-types",
  "bitflags",
  "serde",
  "serde_plain",
@@ -1460,7 +1449,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1491,7 +1480,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1623,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45b6ddbb36c5b969c182aec3c4a0bce7df3fbad4b77114706a49aacc80567388"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1682,7 +1671,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1713,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1738,7 +1727,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1802,7 +1791,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1895,13 +1884,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.9"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
-dependencies = [
- "ctor",
- "version_check",
-]
+checksum = "a4d330786735ea358f3bc09eea4caa098569c1c93f342d9aca0514915022fe7e"
 
 [[package]]
 name = "version_check"
@@ -1952,7 +1937,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
@@ -1986,7 +1971,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 [[package]]
 name = "atspi"
 version = "0.16.0"
+source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#8f254d3e30024574ff1ab1d5cd9c46c44f8fe8ce"
 dependencies = [
  "async-trait",
  "atspi-macros",
@@ -224,6 +225,7 @@ dependencies = [
 [[package]]
 name = "atspi-client"
 version = "0.1.0"
+source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#8f254d3e30024574ff1ab1d5cd9c46c44f8fe8ce"
 dependencies = [
  "atspi",
  "atspi-types",
@@ -235,6 +237,7 @@ dependencies = [
 [[package]]
 name = "atspi-macros"
 version = "0.4.0"
+source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#8f254d3e30024574ff1ab1d5cd9c46c44f8fe8ce"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -249,6 +252,7 @@ dependencies = [
 [[package]]
 name = "atspi-types"
 version = "0.1.0"
+source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#8f254d3e30024574ff1ab1d5cd9c46c44f8fe8ce"
 dependencies = [
  "enumflags2",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
+checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
 dependencies = [
  "async-lock",
  "async-task",
@@ -93,7 +93,7 @@ dependencies = [
  "log",
  "parking",
  "polling",
- "rustix 0.37.3",
+ "rustix",
  "slab",
  "socket2",
  "waker-fn",
@@ -109,6 +109,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9d28b1d97e08915212e2e45310d47854eafa69600756fc735fb788f75199c9"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "autocfg",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,7 +134,7 @@ checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -147,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -158,59 +176,68 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.17",
 ]
 
 [[package]]
 name = "async-task"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
+checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
-version = "0.1.67"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.17",
 ]
 
 [[package]]
 name = "atomic-waker"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "debc29dde2e69f9e47506b525f639ed42300fc014a3e007832592448fa8e4599"
+checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
 name = "atspi"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84f84643816e55c316e2aee59970756c504c68da2f78e03bb27e68dc59ed188"
+version = "0.16.0"
+source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#a7871c5f31c20a131563e5c0018bc2542a981e43"
 dependencies = [
  "async-trait",
  "atspi-macros",
+ "atspi-types",
  "enumflags2",
- "futures-lite",
  "serde",
  "static_assertions",
+ "zbus",
+]
+
+[[package]]
+name = "atspi-client"
+version = "0.1.0"
+source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#a7871c5f31c20a131563e5c0018bc2542a981e43"
+dependencies = [
+ "atspi",
+ "atspi-types",
+ "futures-lite",
  "tracing",
  "zbus",
 ]
 
 [[package]]
 name = "atspi-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6432c4e25d26a53ca417bb61794f87ab2445b2468fdbd74ede295455a0fac2f0"
+version = "0.4.0"
+source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#a7871c5f31c20a131563e5c0018bc2542a981e43"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -219,6 +246,20 @@ dependencies = [
  "serde",
  "syn 1.0.109",
  "zbus",
+ "zvariant",
+]
+
+[[package]]
+name = "atspi-types"
+version = "0.1.0"
+source = "git+https://github.com/odilia-app/atspi?branch=types_crate_v2#a7871c5f31c20a131563e5c0018bc2542a981e43"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "tokio-stream",
+ "zbus",
+ "zbus_names",
  "zvariant",
 ]
 
@@ -256,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c67b173a56acffd6d2326fb7ab938ba0b00a71480e14902b2591c87bc5741e8"
+checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -266,13 +307,14 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-lite",
+ "log",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -306,9 +348,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "ciborium"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -317,15 +359,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half",
@@ -342,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "bitflags",
  "clap_lex",
@@ -363,24 +405,24 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
+checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -425,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -512,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -548,9 +590,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "enumflags2"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75d4cd21b95383444831539909fbb14b9dc3fdceb2a6f5d36577329a1f55ccb"
+checksum = "c041f5090df68b32bcd905365fd51769c8b9d553fe87fde0b683534f10c01bd2"
 dependencies = [
  "enumflags2_derive",
  "serde",
@@ -558,35 +600,24 @@ dependencies = [
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58dc3c5e468259f19f2d46304a6b28f1c3d034442e14b322d2b850e36f6d5ae"
+checksum = "5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.17",
 ]
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -626,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -640,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -650,21 +681,21 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-lite"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -677,21 +708,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -714,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -724,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -794,6 +825,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,9 +841,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -820,13 +860,13 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -846,9 +886,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -870,21 +910,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd550e73688e6d578f0ac2119e32b797a327631a42f9433e59d02e139c8df60d"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
@@ -967,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
 ]
@@ -1036,6 +1070,7 @@ version = "0.3.0"
 dependencies = [
  "async-trait",
  "atspi",
+ "atspi-client",
  "criterion",
  "dashmap",
  "fxhash",
@@ -1125,9 +1160,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
 
 [[package]]
 name = "parking_lot"
@@ -1147,7 +1182,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -1194,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e1f879b2998099c2d69ab9605d145d5b661195627eccc680002c4918a7fb6fa"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
  "bitflags",
@@ -1205,7 +1240,7 @@ dependencies = [
  "libc",
  "log",
  "pin-project-lite",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1226,18 +1261,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -1304,25 +1339,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -1331,7 +1375,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1341,31 +1385,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
-name = "rustix"
-version = "0.36.11"
+name = "regex-syntax"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
-dependencies = [
- "bitflags",
- "errno 0.2.8",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
-]
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rustix"
-version = "0.37.3"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
- "errno 0.3.0",
+ "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys 0.3.0",
- "windows-sys 0.45.0",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1397,9 +1433,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.158"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -1418,20 +1454,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.158"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.17",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -1455,7 +1491,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -1476,6 +1512,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
 ]
 
 [[package]]
@@ -1577,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.8"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+checksum = "45b6ddbb36c5b969c182aec3c4a0bce7df3fbad4b77114706a49aacc80567388"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1602,15 +1648,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
- "rustix 0.36.11",
- "windows-sys 0.42.0",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1636,7 +1682,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -1667,14 +1713,13 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "pin-project-lite",
@@ -1682,25 +1727,25 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.17",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1722,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 
 [[package]]
 name = "toml_edit"
@@ -1751,20 +1796,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.17",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1793,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "once_cell",
@@ -1809,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-tree"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758e983ab7c54fee18403994507e7f212b9005e957ce7984996fac8d11facedb"
+checksum = "4f9742d8df709837409dbb22aa25dd7769c260406f20ff48a2320b80a4a6aed0"
 dependencies = [
  "atty",
  "nu-ansi-term",
@@ -1838,9 +1883,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "valuable"
@@ -1888,9 +1933,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1898,24 +1943,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.17",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1925,9 +1970,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1935,28 +1980,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.17",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1995,26 +2040,20 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -2023,13 +2062,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -2039,10 +2093,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2051,10 +2117,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2063,10 +2141,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2075,53 +2165,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
-name = "winnow"
-version = "0.4.0"
+name = "windows_x86_64_msvc"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deac0939bd6e4f24ab5919fbf751c97a8cfc8543bb083a305ed5c0c10bb241d1"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "xdg"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4583db5cbd4c4c0303df2d15af80f0539db703fa1c68802d4cbbd2dd0f88f6"
+checksum = "688597db5a750e9cad4511cb94729a078e274308099a0382b5b8203bbc767fee"
 dependencies = [
- "dirs",
+ "home",
+]
+
+[[package]]
+name = "xdg-home"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2769203cd13a0c6015d515be729c526d041e9cf2c0cc478d57faee85f40c6dcd"
+dependencies = [
+ "nix",
+ "winapi",
 ]
 
 [[package]]
 name = "xml-rs"
-version = "0.8.4"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+checksum = "2d8f380ae16a37b30e6a2cf67040608071384b1450c189e61bea3ff57cde922d"
 
 [[package]]
 name = "zbus"
-version = "3.11.1"
+version = "3.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc29e76f558b2cb94190e8605ecfe77dd40f5df8c072951714b4b71a97f5848"
+checksum = "6c3d77c9966c28321f1907f0b6c5a5561189d1f7311eea6d94180c6be9daab29"
 dependencies = [
  "async-broadcast",
  "async-executor",
  "async-fs",
  "async-io",
  "async-lock",
+ "async-process",
  "async-recursion",
  "async-task",
  "async-trait",
  "byteorder",
  "derivative",
- "dirs",
  "enumflags2",
  "event-listener",
  "futures-core",
  "futures-sink",
  "futures-util",
  "hex",
- "lazy_static",
  "nix",
  "once_cell",
  "ordered-stream",
@@ -2135,6 +2240,7 @@ dependencies = [
  "tracing",
  "uds_windows",
  "winapi",
+ "xdg-home",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -2142,23 +2248,24 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "3.11.1"
+version = "3.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62a80fd82c011cd08459eaaf1fd83d3090c1b61e6d5284360074a7475af3a85d"
+checksum = "f6e341d12edaff644e539ccbbf7f161601294c9a84ed3d7e015da33155b435af"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "regex",
  "syn 1.0.109",
+ "winnow",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34f314916bd89bdb9934154627fab152f4f28acdda03e7c4c68181b214fe7e3"
+checksum = "82441e6033be0a741157a72951a3e4957d519698f3a824439cc131c5ba77ac2a"
 dependencies = [
  "serde",
  "static_assertions",
@@ -2167,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe4914a985446d6fd287019b5fceccce38303d71407d9e6e711d44954a05d8"
+checksum = "622cc473f10cef1b0d73b7b34a266be30ebdcfaea40ec297dd8cbda088f9f93c"
 dependencies = [
  "byteorder",
  "enumflags2",
@@ -2181,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c20260af4b28b3275d6676c7e2a6be0d4332e8e0aba4616d34007fd84e462a"
+checksum = "5d9c1b57352c25b778257c661f3c4744b7cefb7fc09dd46909a153cce7773da2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2194,9 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b22993dbc4d128a17a3b6c92f1c63872dd67198537ee728d8b5d7c40640a8b"
+checksum = "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,11 @@ pre-release-hook = ["cargo", "fmt"]
 dependent-version = "upgrade"
 
 [workspace.dependencies]
-atspi = { git = "https://github.com/odilia-app/atspi", branch = "types_crate_v2", features = ["tokio", "unstable-traits"] }
-atspi-client = { git = "https://github.com/odilia-app/atspi", branch = "types_crate_v2" }
+#atspi = { git = "https://github.com/odilia-app/atspi", branch = "types_crate_v2", features = ["tokio", "unstable-traits"] }
+atspi = { path = "../atspi/atspi/", features = ["tokio", "unstable-traits"] }
+#atspi-client = { git = "https://github.com/odilia-app/atspi", branch = "types_crate_v2" }
+atspi-client = { path = "../atspi/atspi-client" }
+atspi-types = { path = "../atspi/atspi-types/" }
 odilia-common = { version = "0.3.0", path = "./common" }
 odilia-cache = { version = "0.3.0", path = "./cache" }
 eyre = "0.6.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,11 @@ pre-release-hook = ["cargo", "fmt"]
 dependent-version = "upgrade"
 
 [workspace.dependencies]
-atspi = { git = "https://github.com/odilia-app/atspi", branch = "types_crate_v2", features = ["tokio", "unstable-traits"] }
-atspi-client = { git = "https://github.com/odilia-app/atspi", branch = "types_crate_v2" }
-atspi-types = { git = "https://github.com/odilia-app/atspi", branch = "types_crate_v2" }
+atspi = { git = "https://github.com/odilia-app/atspi", branch = "types_crate_v2", default-features = false, features = ["tokio", "unstable-proxy-traits"] }
+atspi-client = { git = "https://github.com/odilia-app/atspi", default-features = false, branch = "types_crate_v2" }
+atspi-proxies = { git = "https://github.com/odilia-app/atspi", default-features = false, branch = "types_crate_v2" }
+atspi-common = { git = "https://github.com/odilia-app/atspi", default-features = false, branch = "types_crate_v2" }
+atspi-connection = { git = "https://github.com/odilia-app/atspi", default-features = false, branch = "types_crate_v2" }
 odilia-common = { version = "0.3.0", path = "./common" }
 odilia-cache = { version = "0.3.0", path = "./cache" }
 eyre = "0.6.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,9 @@ pre-release-hook = ["cargo", "fmt"]
 dependent-version = "upgrade"
 
 [workspace.dependencies]
-#atspi = { git = "https://github.com/odilia-app/atspi", branch = "types_crate_v2", features = ["tokio", "unstable-traits"] }
-atspi = { path = "../atspi/atspi/", features = ["tokio", "unstable-traits"] }
-#atspi-client = { git = "https://github.com/odilia-app/atspi", branch = "types_crate_v2" }
-atspi-client = { path = "../atspi/atspi-client" }
-atspi-types = { path = "../atspi/atspi-types/" }
+atspi = { git = "https://github.com/odilia-app/atspi", branch = "types_crate_v2", features = ["tokio", "unstable-traits"] }
+atspi-client = { git = "https://github.com/odilia-app/atspi", branch = "types_crate_v2" }
+atspi-types = { git = "https://github.com/odilia-app/atspi", branch = "types_crate_v2" }
 odilia-common = { version = "0.3.0", path = "./common" }
 odilia-cache = { version = "0.3.0", path = "./cache" }
 eyre = "0.6.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ pre-release-hook = ["cargo", "fmt"]
 dependent-version = "upgrade"
 
 [workspace.dependencies]
-atspi = { version = "0.15.1", features = ["tokio", "unstable-traits"] }
+atspi = { git = "https://github.com/odilia-app/atspi", branch = "types_crate_v2", features = ["tokio", "unstable-traits"] }
+atspi-client = { git = "https://github.com/odilia-app/atspi", branch = "types_crate_v2" }
 odilia-common = { version = "0.3.0", path = "./common" }
 odilia-cache = { version = "0.3.0", path = "./cache" }
 eyre = "0.6.8"

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["accessibility"]
 
 [dependencies]
 atspi.workspace = true
+atspi-types.workspace = true
 odilia-common.workspace = true
 dashmap = "5.4.0"
 serde = "1.0.147"

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -13,7 +13,9 @@ categories = ["accessibility"]
 
 [dependencies]
 atspi.workspace = true
-atspi-types.workspace = true
+atspi-proxies.workspace = true
+atspi-common.workspace = true
+atspi-client.workspace = true
 odilia-common.workspace = true
 dashmap = "5.4.0"
 serde = "1.0.147"
@@ -30,7 +32,6 @@ rand = "0.8.5"
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-test = "0.4.2"
-atspi-client.workspace = true
 
 [[bench]]
 name = "load_test"

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -29,6 +29,7 @@ rand = "0.8.5"
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-test = "0.4.2"
+atspi-client.workspace = true
 
 [[bench]]
 name = "load_test"

--- a/cache/benches/load_test.rs
+++ b/cache/benches/load_test.rs
@@ -4,7 +4,7 @@ use std::{
 	time::Duration,
 };
 
-use atspi::{accessible::Accessible};
+use atspi::accessible::Accessible;
 use atspi_client::AccessibilityConnection;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use odilia_cache::{AccessiblePrimitive, Cache, CacheItem};
@@ -43,7 +43,7 @@ async fn traverse_up_refs(children: Vec<Arc<RwLock<CacheItem>>>) {
 		loop {
 			let item_ref_copy = Arc::clone(&item_ref);
 			let mut item = item_ref_copy.write().expect("Could not lock item");
-      let root_ = ROOT_A11Y.clone();
+			let root_ = ROOT_A11Y.clone();
 			if matches!(&item.object.id, root_) {
 				break;
 			}
@@ -71,7 +71,7 @@ async fn traverse_up(children: Vec<CacheItem>) {
 					panic!("Odilia error {:?}", e);
 				}
 			};
-      let root_ = ROOT_A11Y.clone();
+			let root_ = ROOT_A11Y.clone();
 			if matches!(item.object.id.clone(), root_) {
 				break;
 			}
@@ -220,7 +220,11 @@ fn cache_benchmark(c: &mut Criterion) {
 
 	group.bench_function(BenchmarkId::new("traverse_up", "wcag-items"), |b| {
 		b.to_async(&rt).iter_batched(
-			|| children.iter().map(|am| Arc::clone(&am).read().unwrap().clone()).collect(),
+			|| {
+				children.iter()
+					.map(|am| Arc::clone(&am).read().unwrap().clone())
+					.collect()
+			},
 			|cs| async { traverse_up(cs).await },
 			BatchSize::SmallInput,
 		);

--- a/cache/benches/load_test.rs
+++ b/cache/benches/load_test.rs
@@ -4,9 +4,10 @@ use std::{
 	time::Duration,
 };
 
-use atspi::{accessible::Accessible, AccessibilityConnection};
+use atspi::{accessible::Accessible};
+use atspi_client::AccessibilityConnection;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
-use odilia_cache::{clone_arc_mutex, AccessiblePrimitive, Cache, CacheItem};
+use odilia_cache::{AccessiblePrimitive, Cache, CacheItem};
 
 use odilia_common::errors::{CacheError, OdiliaError};
 use tokio::select;
@@ -71,7 +72,7 @@ async fn traverse_up(children: Vec<CacheItem>) {
 				}
 			};
       let root_ = ROOT_A11Y.clone();
-			if matches!(item.object.id, root_) {
+			if matches!(item.object.id.clone(), root_) {
 				break;
 			}
 		}
@@ -219,7 +220,7 @@ fn cache_benchmark(c: &mut Criterion) {
 
 	group.bench_function(BenchmarkId::new("traverse_up", "wcag-items"), |b| {
 		b.to_async(&rt).iter_batched(
-			|| children.iter().map(clone_arc_mutex).collect(),
+			|| children.iter().map(|am| Arc::clone(&am).read().unwrap().clone()).collect(),
 			|cs| async { traverse_up(cs).await },
 			BatchSize::SmallInput,
 		);

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -13,7 +13,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-use atspi_types::{Role, StateSet, InterfaceSet, RelationType, GenericEvent};
 use atspi::{
 	accessible::{Accessible, AccessibleProxy},
 	convertable::Convertable,
@@ -21,6 +20,7 @@ use atspi::{
 	text_ext::TextExt,
 	CoordType,
 };
+use atspi_types::{GenericEvent, InterfaceSet, RelationType, Role, StateSet};
 use dashmap::DashMap;
 use fxhash::FxBuildHasher;
 use odilia_common::{
@@ -43,18 +43,18 @@ type ThreadSafeCache = Arc<InnerCache>;
 /// This makes some *possibly eronious* assumptions about what the sender is.
 pub struct AccessiblePrimitive {
 	/// The accessible ID, which is an arbitrary string specified by the application.
-  /// It is guarenteed to be unique per application.
-  /// Examples:
-  /// * /org/a11y/atspi/accessible/1234
-  /// * /org/a11y/atspi/accessible/null
-  /// * /org/a11y/atspi/accessible/root
-  /// * /org/Gnome/GTK/abab22-bbbb33-2bba2
+	/// It is guarenteed to be unique per application.
+	/// Examples:
+	/// * /org/a11y/atspi/accessible/1234
+	/// * /org/a11y/atspi/accessible/null
+	/// * /org/a11y/atspi/accessible/root
+	/// * /org/Gnome/GTK/abab22-bbbb33-2bba2
 	pub id: String,
 	/// Assuming that the sender is ":x.y", this stores the (x,y) portion of this sender.
-  /// Examples:
-  /// * :1.1 (the first window has opened)
-  /// * :2.5 (a second session exists, where at least 5 applications have been lauinched)
-  /// * :1.262 (many applications have been started on this bus)
+	/// Examples:
+	/// * :1.1 (the first window has opened)
+	/// * :2.5 (a second session exists, where at least 5 applications have been lauinched)
+	/// * :1.262 (many applications have been started on this bus)
 	pub sender: smartstring::alias::String,
 }
 impl AccessiblePrimitive {
@@ -95,11 +95,10 @@ impl AccessiblePrimitive {
 	pub fn from_event<'a, T: GenericEvent<'a>>(
 		event: &T,
 	) -> Result<Self, AccessiblePrimitiveConversionError> {
-		let sender = event
-			.sender();
-			//.map_err(|_| AccessiblePrimitiveConversionError::ErrSender)?
-			//.ok_or(AccessiblePrimitiveConversionError::NoSender)?;
-		let path = event.path();//.ok_or(AccessiblePrimitiveConversionError::NoPathId)?;
+		let sender = event.sender();
+		//.map_err(|_| AccessiblePrimitiveConversionError::ErrSender)?
+		//.ok_or(AccessiblePrimitiveConversionError::NoSender)?;
+		let path = event.path(); //.ok_or(AccessiblePrimitiveConversionError::NoPathId)?;
 		let id = path.to_string();
 		Ok(Self { id, sender: sender.as_str().into() })
 	}
@@ -120,12 +119,14 @@ impl TryFrom<(OwnedUniqueName, OwnedObjectPath)> for AccessiblePrimitive {
 	fn try_from(
 		so: (OwnedUniqueName, OwnedObjectPath),
 	) -> Result<AccessiblePrimitive, Self::Error> {
-		let accessible_id= so.1;
-		Ok(AccessiblePrimitive { id: accessible_id.to_string(), sender: so.0.as_str().into() })
+		let accessible_id = so.1;
+		Ok(AccessiblePrimitive {
+			id: accessible_id.to_string(),
+			sender: so.0.as_str().into(),
+		})
 	}
 }
 impl From<(String, OwnedObjectPath)> for AccessiblePrimitive {
-
 	fn from(so: (String, OwnedObjectPath)) -> AccessiblePrimitive {
 		let accessible_id = so.1;
 		AccessiblePrimitive { id: accessible_id.to_string(), sender: so.0.into() }
@@ -141,7 +142,7 @@ impl<'a> TryFrom<&AccessibleProxy<'a>> for AccessiblePrimitive {
 
 	fn try_from(accessible: &AccessibleProxy<'_>) -> Result<AccessiblePrimitive, Self::Error> {
 		let sender = accessible.destination().as_str().into();
-    let id = accessible.path().as_str().into();
+		let id = accessible.path().as_str().into();
 		Ok(AccessiblePrimitive { id, sender })
 	}
 }
@@ -150,7 +151,7 @@ impl<'a> TryFrom<AccessibleProxy<'a>> for AccessiblePrimitive {
 
 	fn try_from(accessible: AccessibleProxy<'_>) -> Result<AccessiblePrimitive, Self::Error> {
 		let sender = accessible.destination().as_str().into();
-    let id = accessible.path().as_str().into();
+		let id = accessible.path().as_str().into();
 		Ok(AccessiblePrimitive { id, sender })
 	}
 }
@@ -236,9 +237,7 @@ impl CacheItem {
 				.get_children()
 				.await?
 				.into_iter()
-				.map(|child_object_pair| {
-					CacheRef::new(child_object_pair.into())
-				})
+				.map(|child_object_pair| CacheRef::new(child_object_pair.into()))
 				.collect();
 		Ok(Self {
 			object: atspi_cache_item.object.try_into()?,
@@ -901,10 +900,7 @@ pub async fn accessible_to_cache_item(
 		role,
 		states,
 		text,
-		children: children
-			.into_iter()
-			.map(|k| CacheRef::new(k.into()))
-			.collect(),
+		children: children.into_iter().map(|k| CacheRef::new(k.into())).collect(),
 		cache,
 	})
 }

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -13,14 +13,12 @@ use std::{
 };
 
 use async_trait::async_trait;
-use atspi::{
+use atspi_proxies::{
 	accessible::{Accessible, AccessibleProxy},
-	convertable::Convertable,
-	text::{ClipType, Granularity, Text, TextProxy},
-	text_ext::TextExt,
-	CoordType,
+	text::{Text, TextProxy},
 };
-use atspi_types::{GenericEvent, InterfaceSet, RelationType, Role, StateSet};
+use atspi_client::{convertable::Convertable, text_ext::TextExt};
+use atspi_common::{GenericEvent, InterfaceSet, RelationType, Role, StateSet, CoordType, ClipType, Granularity};
 use dashmap::DashMap;
 use fxhash::FxBuildHasher;
 use odilia_common::{
@@ -226,7 +224,7 @@ impl CacheItem {
 	///
 	/// The only time these can fail is if the item is removed on the application side before the conversion to `AccessibleProxy`.
 	pub async fn from_atspi_cache_item(
-		atspi_cache_item: atspi_types::CacheItem,
+		atspi_cache_item: atspi_common::CacheItem,
 		cache: Weak<Cache>,
 		connection: &zbus::Connection,
 	) -> OdiliaResult<Self> {

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -13,12 +13,14 @@ use std::{
 };
 
 use async_trait::async_trait;
+use atspi_client::{convertable::Convertable, text_ext::TextExt};
+use atspi_common::{
+	ClipType, CoordType, GenericEvent, Granularity, InterfaceSet, RelationType, Role, StateSet,
+};
 use atspi_proxies::{
 	accessible::{Accessible, AccessibleProxy},
 	text::{Text, TextProxy},
 };
-use atspi_client::{convertable::Convertable, text_ext::TextExt};
-use atspi_common::{GenericEvent, InterfaceSet, RelationType, Role, StateSet, CoordType, ClipType, Granularity};
 use dashmap::DashMap;
 use fxhash::FxBuildHasher;
 use odilia_common::{

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -58,7 +58,7 @@ pub struct AccessiblePrimitive {
 	pub sender: smartstring::alias::String,
 }
 impl AccessiblePrimitive {
-	/// Convert into an [`atspi::accessible::AccessibleProxy`]. Must be async because the creation of an async proxy requires async itself.
+	/// Convert into an [`atspi_proxies::accessible::AccessibleProxy`]. Must be async because the creation of an async proxy requires async itself.
 	/// # Errors
 	/// Will return a [`zbus::Error`] in the case of an invalid destination, path, or failure to create a `Proxy` from those properties.
 	pub async fn into_accessible<'a>(
@@ -75,7 +75,7 @@ impl AccessiblePrimitive {
 			.build()
 			.await
 	}
-	/// Convert into an [`atspi::text::TextProxy`]. Must be async because the creation of an async proxy requires async itself.
+	/// Convert into an [`atspi_proxies::text::TextProxy`]. Must be async because the creation of an async proxy requires async itself.
 	/// # Errors
 	/// Will return a [`zbus::Error`] in the case of an invalid destination, path, or failure to create a `Proxy` from those properties.
 	pub async fn into_text<'a>(self, conn: &zbus::Connection) -> zbus::Result<TextProxy<'a>> {
@@ -157,7 +157,7 @@ impl<'a> TryFrom<AccessibleProxy<'a>> for AccessiblePrimitive {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-/// A struct representing an accessible. To get any information from the cache other than the stored information like role, interfaces, and states, you will need to instantiate an [`atspi::accessible::AccessibleProxy`] or other `*Proxy` type from atspi to query further info.
+/// A struct representing an accessible. To get any information from the cache other than the stored information like role, interfaces, and states, you will need to instantiate an [`atspi_proxies::accessible::AccessibleProxy`] or other `*Proxy` type from atspi to query further info.
 pub struct CacheItem {
 	// The accessible object (within the application)	(so)
 	pub object: AccessiblePrimitive,
@@ -205,7 +205,7 @@ impl CacheItem {
 	/// This can fail under three possible conditions:
 	///
 	/// 1. We are unable to convert information from the event into an [`AccessiblePrimitive`] hashmap key. This should never happen.
-	/// 2. We are unable to convert the [`AccessiblePrimitive`] to an [`atspi::accessible::AccessibleProxy`].
+	/// 2. We are unable to convert the [`AccessiblePrimitive`] to an [`atspi_proxies::accessible::AccessibleProxy`].
 	/// 3. The `accessible_to_cache_item` function fails for any reason. This also shouldn't happen.
 	pub async fn from_atspi_event<'a, T: GenericEvent<'a>>(
 		event: &T,
@@ -215,13 +215,13 @@ impl CacheItem {
 		let a11y_prim = AccessiblePrimitive::from_event(event)?;
 		accessible_to_cache_item(&a11y_prim.into_accessible(connection).await?, cache).await
 	}
-	/// Convert an [`atspi::cache::CacheItem`] into a [`crate::CacheItem`].
+	/// Convert an [`atspi::CacheItem`] into a [`crate::CacheItem`].
 	/// This requires calls to `DBus`, which is quite expensive. Beware calling this too often.
 	/// # Errors
 	/// This function can fail under the following conditions:
 	///
-	/// 1. The [`atspi::cache::CacheItem`] can not be turned into a [`crate::AccessiblePrimitive`]. This should never happen.
-	/// 2. The [`crate::AccessiblePrimitive`] can not be turned into a [`atspi::accessible::AccessibleProxy`]. This should never happen.
+	/// 1. The [`atspi::CacheItem`] can not be turned into a [`crate::AccessiblePrimitive`]. This should never happen.
+	/// 2. The [`crate::AccessiblePrimitive`] can not be turned into a [`atspi_proxies::accessible::AccessibleProxy`]. This should never happen.
 	/// 3. Getting children from the `AccessibleProxy` fails. This should never happen.
 	///
 	/// The only time these can fail is if the item is removed on the application side before the conversion to `AccessibleProxy`.
@@ -858,7 +858,7 @@ impl Cache {
 	}
 }
 
-/// Convert an [`atspi::accessible::AccessibleProxy`] into a [`crate::CacheItem`].
+/// Convert an [`atspi_proxies::accessible::AccessibleProxy`] into a [`crate::CacheItem`].
 /// This runs a bunch of long-awaiting code and can take quite some time; use this sparingly.
 /// This takes most properties and some function calls through the `AccessibleProxy` structure and generates a new `CacheItem`, which will be written to cache before being sent back.
 ///

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -13,13 +13,13 @@ use std::{
 };
 
 use async_trait::async_trait;
+use atspi_types::{Role, StateSet, InterfaceSet, RelationType, GenericEvent};
 use atspi::{
-	accessible::{Accessible, AccessibleProxy, RelationType, Role},
+	accessible::{Accessible, AccessibleProxy},
 	convertable::Convertable,
-	events::GenericEvent,
 	text::{ClipType, Granularity, Text, TextProxy},
 	text_ext::TextExt,
-	CoordType, InterfaceSet, StateSet,
+	CoordType,
 };
 use dashmap::DashMap;
 use fxhash::FxBuildHasher;
@@ -225,7 +225,7 @@ impl CacheItem {
 	///
 	/// The only time these can fail is if the item is removed on the application side before the conversion to `AccessibleProxy`.
 	pub async fn from_atspi_cache_item(
-		atspi_cache_item: atspi::cache::CacheItem,
+		atspi_cache_item: atspi_types::CacheItem,
 		cache: Weak<Cache>,
 		connection: &zbus::Connection,
 	) -> OdiliaResult<Self> {

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 
 [dependencies]
 atspi.workspace = true
-atspi-types.workspace = true
+atspi-common.workspace = true
 bitflags = "1.3.2"
 serde = "1.0.147"
 smartstring = "1.0.1"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 
 [dependencies]
 atspi.workspace = true
+atspi-types.workspace = true
 bitflags = "1.3.2"
 serde = "1.0.147"
 smartstring = "1.0.1"

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -1,5 +1,5 @@
 use atspi::AtspiError;
-use atspi_types::AtspiError as AtspiTypesError;
+use atspi_common::AtspiError as AtspiTypesError;
 use serde_plain::Error as SerdePlainError;
 use smartstring::alias::String as SmartString;
 use std::{error::Error, fmt, str::FromStr};
@@ -106,11 +106,6 @@ impl From<SerdePlainError> for OdiliaError {
 impl From<AtspiError> for OdiliaError {
 	fn from(err: AtspiError) -> OdiliaError {
 		Self::AtspiError(err)
-	}
-}
-impl From<AtspiTypesError> for OdiliaError {
-	fn from(err: AtspiTypesError) -> OdiliaError {
-		Self::AtspiTypesError(err)
 	}
 }
 impl fmt::Display for OdiliaError {

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -1,4 +1,5 @@
-use atspi::error::AtspiError;
+use atspi_types::AtspiError as AtspiTypesError;
+use atspi::AtspiError;
 use serde_plain::Error as SerdePlainError;
 use smartstring::alias::String as SmartString;
 use std::{error::Error, fmt, str::FromStr};
@@ -6,6 +7,7 @@ use std::{error::Error, fmt, str::FromStr};
 #[derive(Debug)]
 pub enum OdiliaError {
 	AtspiError(AtspiError),
+  AtspiTypesError(AtspiTypesError),
 	PrimitiveConversionError(AccessiblePrimitiveConversionError),
 	NoAttributeError(String),
 	SerdeError(SerdePlainError),
@@ -104,6 +106,11 @@ impl From<SerdePlainError> for OdiliaError {
 impl From<AtspiError> for OdiliaError {
 	fn from(err: AtspiError) -> OdiliaError {
 		Self::AtspiError(err)
+	}
+}
+impl From<AtspiTypesError> for OdiliaError {
+	fn from(err: AtspiTypesError) -> OdiliaError {
+		Self::AtspiTypesError(err)
 	}
 }
 impl fmt::Display for OdiliaError {

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -1,5 +1,5 @@
-use atspi_types::AtspiError as AtspiTypesError;
 use atspi::AtspiError;
+use atspi_types::AtspiError as AtspiTypesError;
 use serde_plain::Error as SerdePlainError;
 use smartstring::alias::String as SmartString;
 use std::{error::Error, fmt, str::FromStr};
@@ -7,7 +7,7 @@ use std::{error::Error, fmt, str::FromStr};
 #[derive(Debug)]
 pub enum OdiliaError {
 	AtspiError(AtspiError),
-  AtspiTypesError(AtspiTypesError),
+	AtspiTypesError(AtspiTypesError),
 	PrimitiveConversionError(AccessiblePrimitiveConversionError),
 	NoAttributeError(String),
 	SerdeError(SerdePlainError),

--- a/common/src/events.rs
+++ b/common/src/events.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::modes::ScreenReaderMode;
-use atspi::accessible::Role;
+use atspi_types::Role;
 
 #[derive(Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 /// A list of features supported natively by Odilia.

--- a/common/src/events.rs
+++ b/common/src/events.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::modes::ScreenReaderMode;
-use atspi_types::Role;
+use atspi_common::Role;
 
 #[derive(Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 /// A list of features supported natively by Odilia.

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1,4 +1,4 @@
-use atspi::text::Granularity;
+use atspi_common::Granularity;
 use serde::{self, Deserialize, Serialize};
 use zbus::zvariant::OwnedObjectPath;
 

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -27,7 +27,9 @@ pre-release-replacements = [
 
 [dependencies]
 atspi.workspace = true
-atspi-types.workspace = true
+atspi-proxies.workspace = true
+atspi-common.workspace = true
+atspi-connection.workspace = true
 atspi-client.workspace = true
 circular-queue = "^0.2.6"
 eyre.workspace = true

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -27,6 +27,8 @@ pre-release-replacements = [
 
 [dependencies]
 atspi.workspace = true
+atspi-types.workspace = true
+atspi-client.workspace = true
 circular-queue = "^0.2.6"
 eyre.workspace = true
 futures = { version = "^0.3.25", default-features = false }

--- a/odilia/src/events/cache.rs
+++ b/odilia/src/events/cache.rs
@@ -14,8 +14,7 @@ pub async fn add_accessible(
 	state: &ScreenReaderState,
 	event: &AddAccessibleEvent,
 ) -> eyre::Result<()> {
-	let atspi_cache_item = event.clone().into_item();
-	state.get_or_create_atspi_cache_item_to_cache(atspi_cache_item)
+	state.get_or_create_atspi_cache_item_to_cache(event.node_added.clone())
 		.await?;
 	Ok(())
 }

--- a/odilia/src/events/document.rs
+++ b/odilia/src/events/document.rs
@@ -1,10 +1,7 @@
 use crate::state::ScreenReaderState;
 use atspi_types::events::{
-  GenericEvent,
-  document::{
-    DocumentEvents,
-    LoadCompleteEvent,
-  },
+	document::{DocumentEvents, LoadCompleteEvent},
+	GenericEvent,
 };
 use odilia_common::errors::OdiliaError;
 

--- a/odilia/src/events/document.rs
+++ b/odilia/src/events/document.rs
@@ -1,5 +1,5 @@
 use crate::state::ScreenReaderState;
-use atspi_types::events::{
+use atspi_common::events::{
 	document::{DocumentEvents, LoadCompleteEvent},
 	GenericEvent,
 };

--- a/odilia/src/events/document.rs
+++ b/odilia/src/events/document.rs
@@ -1,7 +1,10 @@
 use crate::state::ScreenReaderState;
-use atspi::{
-	events::GenericEvent, identify::document::DocumentEvents,
-	identify::document::LoadCompleteEvent,
+use atspi_types::events::{
+  GenericEvent,
+  document::{
+    DocumentEvents,
+    LoadCompleteEvent,
+  },
 };
 use odilia_common::errors::OdiliaError;
 
@@ -9,7 +12,7 @@ pub async fn load_complete(
 	state: &ScreenReaderState,
 	event: &LoadCompleteEvent,
 ) -> Result<(), OdiliaError> {
-	let sender = event.sender()?.ok_or(zbus::Error::MissingField)?;
+	let sender = event.sender();
 	let cache = state.build_cache(sender).await?;
 	// TODO: this should be streamed, rather than waiting for the entire vec to fill up.
 	let entire_cache = cache.get_items().await?;

--- a/odilia/src/events/mod.rs
+++ b/odilia/src/events/mod.rs
@@ -204,7 +204,7 @@ pub mod dispatch_tests {
 	}
 
 	pub async fn generate_state() -> ScreenReaderState {
-		let (send, mut recv) = channel(32);
+		let (send, _recv) = channel(32);
 		let cache = serde_json::from_str(include_str!("wcag_cache_items.json")).unwrap();
 		let state = ScreenReaderState::new(send).await.unwrap();
 		state.cache.add_all(cache).unwrap();

--- a/odilia/src/events/mod.rs
+++ b/odilia/src/events/mod.rs
@@ -11,13 +11,9 @@ use tokio::sync::{
 };
 
 use crate::state::ScreenReaderState;
-use atspi::{
-	accessible_ext::{AccessibleExt, MatcherArgs},
-	component::ScrollType,
-	convertable::Convertable,
-};
-use atspi_types::events::Event;
-use atspi_types::{InterfaceSet, MatchType, Role};
+use atspi_client::{accessible_ext::AccessibleExt, convertable::Convertable};
+use atspi_common::events::Event;
+use atspi_common::{InterfaceSet, MatcherArgs, Role, ScrollType, MatchType};
 use odilia_common::{
 	events::{Direction, ScreenReaderEvent},
 	result::OdiliaResult,

--- a/odilia/src/events/mod.rs
+++ b/odilia/src/events/mod.rs
@@ -13,7 +13,7 @@ use tokio::sync::{
 use crate::state::ScreenReaderState;
 use atspi_client::{accessible_ext::AccessibleExt, convertable::Convertable};
 use atspi_common::events::Event;
-use atspi_common::{InterfaceSet, MatcherArgs, Role, ScrollType, MatchType};
+use atspi_common::{InterfaceSet, MatchType, MatcherArgs, Role, ScrollType};
 use odilia_common::{
 	events::{Direction, ScreenReaderEvent},
 	result::OdiliaResult,

--- a/odilia/src/events/mod.rs
+++ b/odilia/src/events/mod.rs
@@ -11,15 +11,13 @@ use tokio::sync::{
 };
 
 use crate::state::ScreenReaderState;
+use atspi_types::{Role, MatchType, InterfaceSet};
 use atspi::{
-	accessible::Role,
 	accessible_ext::{AccessibleExt, MatcherArgs},
-	collection::MatchType,
 	component::ScrollType,
 	convertable::Convertable,
-	events::{Event, EventInterfaces},
-	InterfaceSet,
 };
+use atspi_types::events::Event;
 use odilia_common::{
 	events::{Direction, ScreenReaderEvent},
 	result::OdiliaResult,
@@ -47,7 +45,7 @@ pub async fn structural_navigation(
 		interfaces,
 		MatchType::Invalid,
 	);
-	if let Some(next) = curr.get_next(&mt, dir == Direction::Backward).await? {
+	if let Some(next) = curr.get_next(&mt, dir == Direction::Backward, &mut Vec::new()).await? {
 		let comp = next.to_component().await?;
 		let texti = next.to_text().await?;
 		let curr_prim = curr.try_into()?;
@@ -175,10 +173,10 @@ async fn dispatch_wrapper(state: Arc<ScreenReaderState>, good_event: Event) {
 async fn dispatch(state: &ScreenReaderState, event: Event) -> eyre::Result<()> {
 	// Dispatch based on interface
 	match &event {
-		Event::Interfaces(EventInterfaces::Object(object_event)) => {
+		Event::Object(object_event) => {
 			object::dispatch(state, object_event).await?;
 		}
-		Event::Interfaces(EventInterfaces::Document(document_event)) => {
+		Event::Document(document_event) => {
 			document::dispatch(state, document_event).await?;
 		}
 		Event::Cache(cache_event) => cache::dispatch(state, cache_event).await?,

--- a/odilia/src/events/mod.rs
+++ b/odilia/src/events/mod.rs
@@ -11,13 +11,13 @@ use tokio::sync::{
 };
 
 use crate::state::ScreenReaderState;
-use atspi_types::{Role, MatchType, InterfaceSet};
 use atspi::{
 	accessible_ext::{AccessibleExt, MatcherArgs},
 	component::ScrollType,
 	convertable::Convertable,
 };
 use atspi_types::events::Event;
+use atspi_types::{InterfaceSet, MatchType, Role};
 use odilia_common::{
 	events::{Direction, ScreenReaderEvent},
 	result::OdiliaResult,
@@ -45,7 +45,10 @@ pub async fn structural_navigation(
 		interfaces,
 		MatchType::Invalid,
 	);
-	if let Some(next) = curr.get_next(&mt, dir == Direction::Backward, &mut Vec::new()).await? {
+	if let Some(next) = curr
+		.get_next(&mt, dir == Direction::Backward, &mut Vec::new())
+		.await?
+	{
 		let comp = next.to_component().await?;
 		let texti = next.to_text().await?;
 		let curr_prim = curr.try_into()?;
@@ -195,20 +198,20 @@ async fn dispatch(state: &ScreenReaderState, event: Event) -> eyre::Result<()> {
 
 #[cfg(test)]
 pub mod dispatch_tests {
-  use crate::ScreenReaderState;
-  use tokio::sync::mpsc::channel;
+	use crate::ScreenReaderState;
+	use tokio::sync::mpsc::channel;
 
-  #[tokio::test]
-  async fn test_full_cache() {
-    let state = generate_state().await;
-    assert_eq!(state.cache.by_id.len(), 14_738);
-  }
+	#[tokio::test]
+	async fn test_full_cache() {
+		let state = generate_state().await;
+		assert_eq!(state.cache.by_id.len(), 14_738);
+	}
 
-  pub async fn generate_state() -> ScreenReaderState {
-    let (send, mut recv) = channel(32);
-    let cache = serde_json::from_str(include_str!("wcag_cache_items.json")).unwrap();
-    let state = ScreenReaderState::new(send).await.unwrap();
-    state.cache.add_all(cache).unwrap();
-    state
-  }
+	pub async fn generate_state() -> ScreenReaderState {
+		let (send, mut recv) = channel(32);
+		let cache = serde_json::from_str(include_str!("wcag_cache_items.json")).unwrap();
+		let state = ScreenReaderState::new(send).await.unwrap();
+		state.cache.add_all(cache).unwrap();
+		state
+	}
 }

--- a/odilia/src/events/mod.rs
+++ b/odilia/src/events/mod.rs
@@ -49,10 +49,10 @@ pub async fn structural_navigation(
 		let comp = next.to_component().await?;
 		let texti = next.to_text().await?;
 		let curr_prim = curr.try_into()?;
-		let _ = comp.grab_focus().await?;
+		let _: bool = comp.grab_focus().await?;
 		comp.scroll_to(ScrollType::TopLeft).await?;
 		state.update_accessible(curr_prim).await;
-		let _ = texti.set_caret_offset(0).await?;
+		let _: bool = texti.set_caret_offset(0).await?;
 		let role = next.get_role().await?;
 		let len = texti.character_count().await?;
 		let text = texti.get_text(0, len).await?;
@@ -84,7 +84,7 @@ pub async fn sr_event(
 			    },
 			    Some(ScreenReaderEvent::StopSpeech) => {
 			      tracing::debug!("Stopping speech!");
-			      let _ = state.stop_speech().await;
+			      let _: bool = state.stop_speech().await;
 			    },
 			    Some(ScreenReaderEvent::ChangeMode(new_sr_mode)) => {
 						tracing::debug!("Changing mode to {:?}", new_sr_mode);

--- a/odilia/src/events/object.rs
+++ b/odilia/src/events/object.rs
@@ -196,7 +196,7 @@ mod text_changed {
 
 	/// The `insert` boolean, if set to true, will update the text in the cache.
 	/// If it is set to false, the selection will be removed.
-	/// The [`TextChangedEvent::kind`] value will *NOT* be checked by this function.
+	/// The [`TextChangedEvent::operation`] value will *NOT* be checked by this function.
 	pub async fn insert_or_delete(
 		state: &ScreenReaderState,
 		event: &TextChangedEvent,

--- a/odilia/src/events/object.rs
+++ b/odilia/src/events/object.rs
@@ -526,8 +526,8 @@ mod state_changed {
 #[cfg(test)]
 mod tests {
 	use crate::events::object::text_caret_moved::new_position;
-	use atspi_connection::AccessibilityConnection;
 	use atspi_common::{Interface, InterfaceSet, Role, State, StateSet};
+	use atspi_connection::AccessibilityConnection;
 	use lazy_static::lazy_static;
 	use odilia_cache::{AccessiblePrimitive, Cache, CacheItem};
 	use std::sync::Arc;

--- a/odilia/src/events/object.rs
+++ b/odilia/src/events/object.rs
@@ -1,5 +1,5 @@
 use crate::state::ScreenReaderState;
-use atspi_types::events::object::ObjectEvents;
+use atspi_common::events::object::ObjectEvents;
 
 pub async fn dispatch(state: &ScreenReaderState, event: &ObjectEvents) -> eyre::Result<()> {
 	// Dispatch based on member
@@ -25,7 +25,7 @@ pub async fn dispatch(state: &ScreenReaderState, event: &ObjectEvents) -> eyre::
 
 mod text_changed {
 	use crate::state::ScreenReaderState;
-	use atspi_types::events::object::TextChangedEvent;
+	use atspi_common::events::object::TextChangedEvent;
 	use odilia_cache::CacheItem;
 	use odilia_common::{
 		errors::OdiliaError,
@@ -246,7 +246,7 @@ mod text_changed {
 
 mod children_changed {
 	use crate::state::ScreenReaderState;
-	use atspi_types::events::object::ChildrenChangedEvent;
+	use atspi_common::events::object::ChildrenChangedEvent;
 	use odilia_cache::{AccessiblePrimitive, CacheItem};
 	use odilia_common::{errors::OdiliaError, result::OdiliaResult};
 	use std::sync::Arc;
@@ -293,8 +293,9 @@ mod children_changed {
 
 mod text_caret_moved {
 	use crate::state::ScreenReaderState;
-	use atspi::text::{Granularity, Text};
-	use atspi_types::events::object::TextCaretMovedEvent;
+	use atspi_common::Granularity;
+  use atspi_proxies::text::Text;
+	use atspi_common::events::object::TextCaretMovedEvent;
 	use odilia_cache::CacheItem;
 	use odilia_common::errors::{CacheError, OdiliaError};
 	use ssip_client_async::Priority;
@@ -430,8 +431,8 @@ mod text_caret_moved {
 
 mod state_changed {
 	use crate::state::ScreenReaderState;
-	use atspi::accessible::Accessible;
-	use atspi_types::{events::object::StateChangedEvent, State};
+	use atspi_proxies::accessible::Accessible;
+	use atspi_common::{events::object::StateChangedEvent, State};
 	use odilia_cache::AccessiblePrimitive;
 
 	/// Update the state of an item in the cache using a `StateChanged` event and the `ScreenReaderState` as context.
@@ -526,7 +527,7 @@ mod state_changed {
 mod tests {
 	use crate::events::object::text_caret_moved::new_position;
 	use atspi_client::AccessibilityConnection;
-	use atspi_types::{Interface, InterfaceSet, Role, State, StateSet};
+	use atspi_common::{Interface, InterfaceSet, Role, State, StateSet};
 	use lazy_static::lazy_static;
 	use odilia_cache::{AccessiblePrimitive, Cache, CacheItem};
 	use std::sync::Arc;

--- a/odilia/src/events/object.rs
+++ b/odilia/src/events/object.rs
@@ -209,7 +209,7 @@ mod text_changed {
 		// only after should we try to update the cache
 		if insert {
 			let attributes = accessible.get_attributes().await?;
-			let _ = speak_insertion(state, event, &attributes, &current_text).await;
+			let _: OdiliaResult<()> = speak_insertion(state, event, &attributes, &current_text).await;
 		}
 
 		let text_selection_from_cache: String = current_text
@@ -243,10 +243,15 @@ mod text_changed {
 mod children_changed {
 	use crate::state::ScreenReaderState;
   use atspi_types::events::object::ChildrenChangedEvent;
-	use odilia_cache::AccessiblePrimitive;
-	use odilia_common::errors::OdiliaError;
+	use odilia_cache::{
+    AccessiblePrimitive,
+    CacheItem,
+  };
+	use odilia_common::{
+    errors::OdiliaError,
+    result::OdiliaResult,
+  };
 	use std::sync::Arc;
-	use zbus::zvariant::ObjectPath;
 
 	pub async fn dispatch(
 		state: &ScreenReaderState,
@@ -267,7 +272,7 @@ mod children_changed {
 		let accessible = get_child_primitive(event)?
 			.into_accessible(state.atspi.connection())
 			.await?;
-		let _ = state
+		let _: OdiliaResult<CacheItem> = state
 			.cache
 			.get_or_create(&accessible, Arc::downgrade(&Arc::clone(&state.cache)))
 			.await;

--- a/odilia/src/events/object.rs
+++ b/odilia/src/events/object.rs
@@ -167,7 +167,10 @@ mod text_changed {
 			"insert" => insert_or_delete(state, event, true).await?,
 			"delete/system" => insert_or_delete(state, event, false).await?,
 			"delete" => insert_or_delete(state, event, false).await?,
-			_ => tracing::trace!("TextChangedEvent has invalid kind: {}", event.operation),
+			_ => tracing::trace!(
+				"TextChangedEvent has invalid kind: {}",
+				event.operation
+			),
 		};
 		Ok(())
 	}
@@ -209,7 +212,8 @@ mod text_changed {
 		// only after should we try to update the cache
 		if insert {
 			let attributes = accessible.get_attributes().await?;
-			let _: OdiliaResult<()> = speak_insertion(state, event, &attributes, &current_text).await;
+			let _: OdiliaResult<()> =
+				speak_insertion(state, event, &attributes, &current_text).await;
 		}
 
 		let text_selection_from_cache: String = current_text
@@ -242,15 +246,9 @@ mod text_changed {
 
 mod children_changed {
 	use crate::state::ScreenReaderState;
-  use atspi_types::events::object::ChildrenChangedEvent;
-	use odilia_cache::{
-    AccessiblePrimitive,
-    CacheItem,
-  };
-	use odilia_common::{
-    errors::OdiliaError,
-    result::OdiliaResult,
-  };
+	use atspi_types::events::object::ChildrenChangedEvent;
+	use odilia_cache::{AccessiblePrimitive, CacheItem};
+	use odilia_common::{errors::OdiliaError, result::OdiliaResult};
 	use std::sync::Arc;
 
 	pub async fn dispatch(
@@ -283,9 +281,7 @@ mod children_changed {
 	fn get_child_primitive(
 		event: &ChildrenChangedEvent,
 	) -> Result<AccessiblePrimitive, OdiliaError> {
-		Ok(event.child
-			.clone()
-			.try_into()?)
+		Ok(event.child.clone().try_into()?)
 	}
 	pub fn remove(state: &ScreenReaderState, event: &ChildrenChangedEvent) -> eyre::Result<()> {
 		let prim = get_child_primitive(event)?;
@@ -297,10 +293,8 @@ mod children_changed {
 
 mod text_caret_moved {
 	use crate::state::ScreenReaderState;
-  use atspi_types::events::object::TextCaretMovedEvent;
-	use atspi::{
-		text::{Granularity, Text},
-	};
+	use atspi::text::{Granularity, Text};
+	use atspi_types::events::object::TextCaretMovedEvent;
 	use odilia_cache::CacheItem;
 	use odilia_common::errors::{CacheError, OdiliaError};
 	use ssip_client_async::Priority;
@@ -427,20 +421,17 @@ mod text_caret_moved {
 		state: &ScreenReaderState,
 		event: &TextCaretMovedEvent,
 	) -> eyre::Result<()> {
-    text_cursor_moved(state, event).await?;
+		text_cursor_moved(state, event).await?;
 
-		state.previous_caret_position
-			.store(event.position, Ordering::Relaxed);
+		state.previous_caret_position.store(event.position, Ordering::Relaxed);
 		Ok(())
 	}
 } // end of text_caret_moved
 
 mod state_changed {
 	use crate::state::ScreenReaderState;
-  use atspi_types::{State, events::object::StateChangedEvent};
-	use atspi::{
-		accessible::Accessible,
-	};
+	use atspi::accessible::Accessible;
+	use atspi_types::{events::object::StateChangedEvent, State};
 	use odilia_cache::AccessiblePrimitive;
 
 	/// Update the state of an item in the cache using a `StateChanged` event and the `ScreenReaderState` as context.
@@ -535,7 +526,7 @@ mod state_changed {
 mod tests {
 	use crate::events::object::text_caret_moved::new_position;
 	use atspi_client::AccessibilityConnection;
-  use atspi_types::{InterfaceSet, State, StateSet, Role, Interface};
+	use atspi_types::{Interface, InterfaceSet, Role, State, StateSet};
 	use lazy_static::lazy_static;
 	use odilia_cache::{AccessiblePrimitive, Cache, CacheItem};
 	use std::sync::Arc;
@@ -552,7 +543,10 @@ mod tests {
 				id: "/org/a11y/atspi/accessible/1".to_string(),
 				sender: ":1.2".into(),
 			},
-			app: AccessiblePrimitive { id: "/org/a11y/atspi/accessible/root".to_string(), sender: ":1.2".into() },
+			app: AccessiblePrimitive {
+				id: "/org/a11y/atspi/accessible/root".to_string(),
+				sender: ":1.2".into()
+			},
 			parent: AccessiblePrimitive {
 				id: "/otg/a11y/atspi/accessible/1".to_string(),
 				sender: ":1.2".into(),

--- a/odilia/src/events/object.rs
+++ b/odilia/src/events/object.rs
@@ -293,9 +293,9 @@ mod children_changed {
 
 mod text_caret_moved {
 	use crate::state::ScreenReaderState;
-	use atspi_common::Granularity;
-  use atspi_proxies::text::Text;
 	use atspi_common::events::object::TextCaretMovedEvent;
+	use atspi_common::Granularity;
+	use atspi_proxies::text::Text;
 	use odilia_cache::CacheItem;
 	use odilia_common::errors::{CacheError, OdiliaError};
 	use ssip_client_async::Priority;
@@ -431,8 +431,8 @@ mod text_caret_moved {
 
 mod state_changed {
 	use crate::state::ScreenReaderState;
-	use atspi_proxies::accessible::Accessible;
 	use atspi_common::{events::object::StateChangedEvent, State};
+	use atspi_proxies::accessible::Accessible;
 	use odilia_cache::AccessiblePrimitive;
 
 	/// Update the state of an item in the cache using a `StateChanged` event and the `ScreenReaderState` as context.

--- a/odilia/src/events/object.rs
+++ b/odilia/src/events/object.rs
@@ -526,7 +526,7 @@ mod state_changed {
 #[cfg(test)]
 mod tests {
 	use crate::events::object::text_caret_moved::new_position;
-	use atspi_client::AccessibilityConnection;
+	use atspi_connection::AccessibilityConnection;
 	use atspi_common::{Interface, InterfaceSet, Role, State, StateSet};
 	use lazy_static::lazy_static;
 	use odilia_cache::{AccessiblePrimitive, Cache, CacheItem};

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -26,7 +26,7 @@ use crate::state::ScreenReaderState;
 use odilia_input::sr_event_receiver;
 use ssip_client_async::Priority;
 
-use atspi::identify::{document, object};
+use atspi_types::events::{document, object};
 
 async fn sigterm_signal_watcher(shutdown_tx: broadcast::Sender<i32>) -> eyre::Result<()> {
 	let mut c = signal(SignalKind::interrupt())?;
@@ -41,7 +41,7 @@ async fn sigterm_signal_watcher(shutdown_tx: broadcast::Sender<i32>) -> eyre::Re
 async fn main() -> eyre::Result<()> {
 	logging::init();
 	// Make sure applications with dynamic accessibility supprt do expose their AT-SPI2 interfaces.
-	if let Err(e) = atspi::set_session_accessibility(true).await {
+	if let Err(e) = atspi_client::set_session_accessibility(true).await {
 		tracing::debug!("Could not set AT-SPI2 IsEnabled property because: {}", e);
 	}
 	let (shutdown_tx, _) = broadcast::channel(1);

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -26,7 +26,7 @@ use crate::state::ScreenReaderState;
 use odilia_input::sr_event_receiver;
 use ssip_client_async::Priority;
 
-use atspi_types::events::{document, object};
+use atspi_common::events::{document, object};
 
 async fn sigterm_signal_watcher(shutdown_tx: broadcast::Sender<i32>) -> eyre::Result<()> {
 	let mut c = signal(SignalKind::interrupt())?;
@@ -41,7 +41,7 @@ async fn sigterm_signal_watcher(shutdown_tx: broadcast::Sender<i32>) -> eyre::Re
 async fn main() -> eyre::Result<()> {
 	logging::init();
 	// Make sure applications with dynamic accessibility supprt do expose their AT-SPI2 interfaces.
-	if let Err(e) = atspi_client::set_session_accessibility(true).await {
+	if let Err(e) = atspi_connection::set_session_accessibility(true).await {
 		tracing::debug!("Could not set AT-SPI2 IsEnabled property because: {}", e);
 	}
 	let (shutdown_tx, _) = broadcast::channel(1);

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -18,7 +18,7 @@ use eyre::WrapErr;
 use futures::future::FutureExt;
 use tokio::{
 	signal::unix::{signal, SignalKind},
-	sync::broadcast,
+	sync::broadcast::{self, error::SendError},
 	sync::mpsc,
 };
 
@@ -33,7 +33,7 @@ async fn sigterm_signal_watcher(shutdown_tx: broadcast::Sender<i32>) -> eyre::Re
 	tracing::debug!("Watching for Ctrl+C");
 	c.recv().await;
 	tracing::debug!("Asking all processes to stop.");
-	let _ = shutdown_tx.send(0);
+	let _: Result<usize, SendError<i32>> = shutdown_tx.send(0);
 	Ok(())
 }
 
@@ -61,7 +61,7 @@ async fn main() -> eyre::Result<()> {
 		tracing::debug!("Welcome message spoken.");
 	} else {
 		tracing::debug!("Welcome message failed. Odilia is not able to continue in this state. Existing now.");
-		let _ = state.close_speech().await;
+		let _: bool = state.close_speech().await;
 		exit(1);
 	}
 

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -260,12 +260,8 @@ impl ScreenReaderState {
 		&self,
 		event: &T,
 	) -> OdiliaResult<AccessibleProxy<'_>> {
-		let sender = event
-			.sender()
-			.to_owned();
-		let path = event
-			.path()
-			.to_owned();
+		let sender = event.sender().to_owned();
+		let path = event.path().to_owned();
 		Ok(AccessibleProxy::builder(self.connection())
 			.cache_properties(zbus::CacheProperties::No)
 			.destination(sender)?

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -7,15 +7,19 @@ use tokio::sync::{mpsc::Sender, Mutex};
 use tracing::debug;
 use zbus::{fdo::DBusProxy, names::UniqueName, zvariant::ObjectPath, MatchRule, MessageType};
 
-use atspi::{
-	accessible::AccessibleProxy,
+use atspi_client::{
 	accessible_ext::AccessibleExt,
-	cache::CacheProxy,
 	convertable::Convertable,
+};
+use atspi_proxies::{
+	accessible::AccessibleProxy,
+	cache::CacheProxy,
+};
+use atspi_connection::AccessibilityConnection;
+use atspi_common::{
+  Event,
 	events::{GenericEvent, HasMatchRule, HasRegistryEventString},
 };
-use atspi_client::AccessibilityConnection;
-use atspi_types::Event;
 use odilia_cache::{AccessiblePrimitive, Cache, CacheItem};
 use odilia_common::{
 	errors::{CacheError, ConfigError},
@@ -88,7 +92,7 @@ impl ScreenReaderState {
 
 	pub async fn get_or_create_atspi_cache_item_to_cache(
 		&self,
-		atspi_cache_item: atspi_types::CacheItem,
+		atspi_cache_item: atspi_common::CacheItem,
 	) -> OdiliaResult<CacheItem> {
 		let prim = atspi_cache_item.object.clone().try_into()?;
 		if self.cache.get(&prim).is_none() {

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -18,7 +18,7 @@ use atspi_client::AccessibilityConnection;
 use atspi_types::Event;
 use odilia_cache::{AccessiblePrimitive, Cache, CacheItem};
 use odilia_common::{
-	errors::{AccessiblePrimitiveConversionError, CacheError, ConfigError, OdiliaError},
+	errors::{CacheError, ConfigError},
 	modes::ScreenReaderMode,
 	settings::ApplicationConfig,
 	types::TextSelectionArea,

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -7,19 +7,13 @@ use tokio::sync::{mpsc::Sender, Mutex};
 use tracing::debug;
 use zbus::{fdo::DBusProxy, names::UniqueName, zvariant::ObjectPath, MatchRule, MessageType};
 
-use atspi_client::{
-	accessible_ext::AccessibleExt,
-	convertable::Convertable,
-};
-use atspi_proxies::{
-	accessible::AccessibleProxy,
-	cache::CacheProxy,
+use atspi_client::{accessible_ext::AccessibleExt, convertable::Convertable};
+use atspi_common::{
+	events::{GenericEvent, HasMatchRule, HasRegistryEventString},
+	Event,
 };
 use atspi_connection::AccessibilityConnection;
-use atspi_common::{
-  Event,
-	events::{GenericEvent, HasMatchRule, HasRegistryEventString},
-};
+use atspi_proxies::{accessible::AccessibleProxy, cache::CacheProxy};
 use odilia_cache::{AccessiblePrimitive, Cache, CacheItem};
 use odilia_common::{
 	errors::{CacheError, ConfigError},


### PR DESCRIPTION
[The latest AT-SPI update](https://github.com/odilia-app/atspi/pull/82) introduces many breaking changes that require a bit of a refactor. This updates Odilia to use the latest API.

I'll update this to be in tune with the updated branch until it's merged. Then, I'll switch it to using a version from crates.io instead of a path.