### PR TITLE
Fix-should-panic-lint

### DIFF
--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -231,7 +231,7 @@ impl CacheItem {
 		connection: &zbus::Connection,
 	) -> OdiliaResult<Self> {
 		let children: Vec<CacheRef> =
-			AccessiblePrimitive::try_from(atspi_cache_item.object.clone())?
+			AccessiblePrimitive::from(atspi_cache_item.object.clone())
 				.into_accessible(connection)
 				.await?
 				.get_children()
@@ -240,9 +240,9 @@ impl CacheItem {
 				.map(|child_object_pair| CacheRef::new(child_object_pair.into()))
 				.collect();
 		Ok(Self {
-			object: atspi_cache_item.object.try_into()?,
-			app: atspi_cache_item.app.try_into()?,
-			parent: CacheRef::new(atspi_cache_item.parent.try_into()?),
+			object: atspi_cache_item.object.into(),
+			app: atspi_cache_item.app.into(),
+			parent: CacheRef::new(atspi_cache_item.parent.into()),
 			index: atspi_cache_item.index,
 			children_num: atspi_cache_item.children,
 			interfaces: atspi_cache_item.ifaces,
@@ -376,7 +376,7 @@ impl Accessible for CacheItem {
 					object_pairs
 						.into_iter()
 						.map(|object_pair| {
-							cache.get(&object_pair.try_into()?).ok_or(
+							cache.get(&object_pair.into()).ok_or(
 								OdiliaError::Cache(
 									CacheError::NoItem,
 								),
@@ -565,8 +565,7 @@ impl Text for CacheItem {
 				})
 				// get "all" words that match; there should be only one result
 				.collect::<Vec<_>>()
-				// get the first result
-				.get(0)
+				.first()
 				// if there's no matching word (out of bounds)
 				.ok_or_else(|| OdiliaError::Generic("Out of bounds".to_string()))?
 				// clone the reference into a value
@@ -892,8 +891,8 @@ pub async fn accessible_to_cache_item(
 	}?;
 	Ok(CacheItem {
 		object: accessible.try_into()?,
-		app: app.try_into()?,
-		parent: CacheRef::new(parent.try_into()?),
+		app: app.into(),
+		parent: CacheRef::new(parent.into()),
 		index,
 		children_num,
 		interfaces,

--- a/input/examples/generate-json.rs
+++ b/input/examples/generate-json.rs
@@ -1,5 +1,4 @@
 use odilia_common::{events::ScreenReaderEvent, modes::ScreenReaderMode};
-use serde_json;
 
 fn main() {
 	// a blank event that does nothing

--- a/input/src/lib.rs
+++ b/input/src/lib.rs
@@ -98,7 +98,7 @@ pub async fn sr_event_receiver(
 	if Path::new(&sock_file_path).exists() {
 		tracing::trace!("Sockfile exists, attempting to remove it.");
 		match fs::remove_file(&sock_file_path).await {
-			Ok(_) => {
+			Ok(()) => {
 				tracing::debug!("Removed old socket file");
 			}
 			Err(e) => {
@@ -113,7 +113,7 @@ pub async fn sr_event_receiver(
 	}
 
 	match fs::write(&pid_file_path, id().to_string()).await {
-		Ok(_) => {}
+		Ok(()) => {}
 		Err(e) => {
 			tracing::error!("Unable to write to {}: {}", pid_file_path, e);
 			exit(1);

--- a/input/src/lib.rs
+++ b/input/src/lib.rs
@@ -7,6 +7,7 @@
 	unsafe_code
 )]
 
+use eyre::Context;
 use nix::unistd::Uid;
 use odilia_common::events::ScreenReaderEvent;
 use std::{
@@ -119,7 +120,7 @@ pub async fn sr_event_receiver(
 		}
 	}
 
-	let listener = UnixListener::bind(sock_file_path).expect("Could not open socket");
+	let listener = UnixListener::bind(sock_file_path).context("Could not open socket")?;
 	tracing::debug!("Listener activated!");
 	loop {
 		tokio::select! {

--- a/odilia/src/events/mod.rs
+++ b/odilia/src/events/mod.rs
@@ -195,19 +195,21 @@ async fn dispatch(state: &ScreenReaderState, event: Event) -> eyre::Result<()> {
 #[cfg(test)]
 pub mod dispatch_tests {
 	use crate::ScreenReaderState;
-	use tokio::sync::mpsc::channel;
+	use eyre::Context;
+use tokio::sync::mpsc::channel;
 
 	#[tokio::test]
-	async fn test_full_cache() {
-		let state = generate_state().await;
+	async fn test_full_cache() ->eyre::Result<()>{
+		let state = generate_state().await?;
 		assert_eq!(state.cache.by_id.len(), 14_738);
+	Ok(())
 	}
 
-	pub async fn generate_state() -> ScreenReaderState {
+	pub async fn generate_state() -> eyre::Result<ScreenReaderState> {
 		let (send, _recv) = channel(32);
-		let cache = serde_json::from_str(include_str!("wcag_cache_items.json")).unwrap();
-		let state = ScreenReaderState::new(send).await.unwrap();
-		state.cache.add_all(cache).unwrap();
-		state
+		let cache = serde_json::from_str(include_str!("wcag_cache_items.json")).context("unable to load cache data from json file")?;
+		let state = ScreenReaderState::new(send).await.context("unable to realise screenreader state")?;
+		state.cache.add_all(cache).context("unable to add cache to the system")?;
+		Ok(state)
 	}
 }

--- a/odilia/src/events/mod.rs
+++ b/odilia/src/events/mod.rs
@@ -196,20 +196,25 @@ async fn dispatch(state: &ScreenReaderState, event: Event) -> eyre::Result<()> {
 pub mod dispatch_tests {
 	use crate::ScreenReaderState;
 	use eyre::Context;
-use tokio::sync::mpsc::channel;
+	use tokio::sync::mpsc::channel;
 
 	#[tokio::test]
-	async fn test_full_cache() ->eyre::Result<()>{
+	async fn test_full_cache() -> eyre::Result<()> {
 		let state = generate_state().await?;
 		assert_eq!(state.cache.by_id.len(), 14_738);
-	Ok(())
+		Ok(())
 	}
 
 	pub async fn generate_state() -> eyre::Result<ScreenReaderState> {
 		let (send, _recv) = channel(32);
-		let cache = serde_json::from_str(include_str!("wcag_cache_items.json")).context("unable to load cache data from json file")?;
-		let state = ScreenReaderState::new(send).await.context("unable to realise screenreader state")?;
-		state.cache.add_all(cache).context("unable to add cache to the system")?;
+		let cache = serde_json::from_str(include_str!("wcag_cache_items.json"))
+			.context("unable to load cache data from json file")?;
+		let state = ScreenReaderState::new(send)
+			.await
+			.context("unable to realise screenreader state")?;
+		state.cache
+			.add_all(cache)
+			.context("unable to add cache to the system")?;
 		Ok(state)
 	}
 }

--- a/odilia/src/events/object.rs
+++ b/odilia/src/events/object.rs
@@ -188,7 +188,7 @@ mod text_changed {
 		// if atomic state is false, then only read out the portion which has been added
 		// otherwise, do not continue through this function
 		let text_to_say =
-			if atomic { cache_text.to_string() } else { (&event.text).try_into()? };
+			if atomic { cache_text.to_string() } else { (&event.text).into() };
 		let prioirty = live_to_priority(&live);
 		state.say(prioirty, text_to_say).await;
 		Ok(())
@@ -204,7 +204,7 @@ mod text_changed {
 	) -> eyre::Result<()> {
 		let accessible = state.new_accessible(event).await?;
 		let cache_item = state.get_or_create_event_object_to_cache(event).await?;
-		let updated_text: String = (&event.text).try_into()?;
+		let updated_text: String = (&event.text).into();
 		let current_text = cache_item.text;
 		let (start_pos, update_length) =
 			(usize::try_from(event.start_pos)?, usize::try_from(event.length)?);

--- a/odilia/src/events/object.rs
+++ b/odilia/src/events/object.rs
@@ -536,6 +536,7 @@ mod tests {
 	static A11Y_PARAGRAPH_STRING: &str = "The AT-SPI (Assistive Technology Service Provider Interface) enables users of Linux to use their computer without sighted assistance. It was originally developed at Sun Microsystems, before they were purchased by Oracle.";
 	lazy_static! {
 		static ref ZBUS_CONN: AccessibilityConnection =
+			#[allow(clippy::unwrap_used)]
 			block_on(AccessibilityConnection::open()).unwrap();
 		static ref CACHE_ARC: Arc<Cache> =
 			Arc::new(Cache::new(ZBUS_CONN.connection().clone()));

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -85,14 +85,14 @@ async fn main() -> eyre::Result<()> {
 	let mut shutdown_rx_atspi_recv = shutdown_tx.subscribe();
 	let atspi_event_receiver =
 		events::receive(Arc::clone(&state), atspi_event_tx, &mut shutdown_rx_atspi_recv)
-			.map(|_| Ok::<_, eyre::Report>(()));
+			.map(|()| Ok::<_, eyre::Report>(()));
 	let mut shutdown_rx_atspi_proc_recv = shutdown_tx.subscribe();
 	let atspi_event_processor = events::process(
 		Arc::clone(&state),
 		&mut atspi_event_rx,
 		&mut shutdown_rx_atspi_proc_recv,
 	)
-	.map(|_| Ok::<_, eyre::Report>(()));
+	.map(|()| Ok::<_, eyre::Report>(()));
 	let mut shutdown_rx_odilia_recv = shutdown_tx.subscribe();
 	let odilia_event_receiver = sr_event_receiver(sr_event_tx, &mut shutdown_rx_odilia_recv)
 		.map(|r| r.wrap_err("Could not process Odilia events"));

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -88,7 +88,7 @@ impl ScreenReaderState {
 		&self,
 		atspi_cache_item: atspi_common::CacheItem,
 	) -> OdiliaResult<CacheItem> {
-		let prim = atspi_cache_item.object.clone().try_into()?;
+		let prim = atspi_cache_item.object.clone().into();
 		if self.cache.get(&prim).is_none() {
 			self.cache.add(CacheItem::from_atspi_cache_item(
 				atspi_cache_item,

--- a/tts/src/lib.rs
+++ b/tts/src/lib.rs
@@ -7,6 +7,7 @@
 	unsafe_code
 )]
 
+use eyre::Context;
 use ssip_client_async::{
 	fifo::asynchronous_tokio::Builder,
 	tokio::{AsyncClient, Request},
@@ -41,7 +42,8 @@ pub async fn create_ssip_client(
               .stdout(Stdio::null())
               .stderr(Stdio::null())
               .spawn()
-              .expect("Error running `speech-dispatcher --spawn`; this is a fatal error.");
+              .context("Error running `speech-dispatcher --spawn`; this is a fatal error.")
+			?;
 					tracing::debug!(
 						"Attempting to connect to speech-dispatcher again!"
 					);


### PR DESCRIPTION
this is especially needed because without it, everyone else's pull requests will break on the CI step, requiring ignoring by maintainers, which is harder work because now we have to filter out what we know to be clippy errors related to legacy code, and what is new lints detected on new code, which no one should do
assuming this passes tests, it should be merged right away, and existing unmerged pull requests should afterwards rebase upon main