### PR TITLE
Fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ To build odilia, copy paste the following on your command line . The following s
 ```shell
 git clone https://github.com/odilia-app/odilia  && \
 cd odilia && \
-cargo build --release && \
 cargo install --path odilia
 ```
 

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -28,6 +28,7 @@ smartstring = { version = "1.0.1", features = ["serde"] }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
+atspi-connection.workspace = true
 rand = "0.8.5"
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/cache/benches/load_test.rs
+++ b/cache/benches/load_test.rs
@@ -4,8 +4,6 @@ use std::{
 	time::Duration,
 };
 
-use atspi::accessible::Accessible;
-use atspi_client::AccessibilityConnection;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use odilia_cache::{AccessiblePrimitive, Cache, CacheItem};
 

--- a/cache/benches/load_test.rs
+++ b/cache/benches/load_test.rs
@@ -23,13 +23,13 @@ macro_rules! load_items {
 /// This is different from `add` in that it postpones populating references
 /// until after all items have been added.
 fn add_all(cache: &Cache, items: Vec<CacheItem>) {
-	cache.add_all(items);
+	let _ = cache.add_all(items);
 }
 
 /// Load the given items into cache via repeated `Cache::add`.
 fn add(cache: &Cache, items: Vec<CacheItem>) {
 	for item in items {
-		cache.add(item);
+		let _ = cache.add(item);
 	}
 }
 
@@ -43,7 +43,7 @@ async fn traverse_up_refs(children: Vec<Arc<RwLock<CacheItem>>>) {
 		loop {
 			let item_ref_copy = Arc::clone(&item_ref);
 			let mut item = item_ref_copy.write().expect("Could not lock item");
-			let _root = ROOT_A11Y.clone();
+			let _root = ROOT_A11Y;
 			if matches!(&item.object.id, _root) {
 				break;
 			}
@@ -71,8 +71,8 @@ async fn traverse_up(children: Vec<CacheItem>) {
 					panic!("Odilia error {:?}", e);
 				}
 			};
-			let root_ = ROOT_A11Y.clone();
-			if matches!(item.object.id.clone(), root_) {
+			let _root = ROOT_A11Y;
+			if matches!(item.object.id.clone(), _root) {
 				break;
 			}
 		}
@@ -93,7 +93,7 @@ async fn reads_while_writing(cache: Cache, ids: Vec<AccessiblePrimitive>, items:
 	let cache_1 = Arc::new(cache);
 	let cache_2 = Arc::clone(&cache_1);
 	let mut write_handle = tokio::spawn(async move {
-		cache_1.add_all(items);
+		let _ = cache_1.add_all(items);
 	});
 	let mut read_handle = tokio::spawn(async move {
 		let mut ids = VecDeque::from(ids);
@@ -196,7 +196,7 @@ fn cache_benchmark(c: &mut Criterion) {
 				item
 			})
 			.collect();
-		cache.add_all(all_items);
+		let _ = cache.add_all(all_items);
 		let children = cache
 			.by_id
 			.iter()

--- a/cache/benches/load_test.rs
+++ b/cache/benches/load_test.rs
@@ -43,8 +43,8 @@ async fn traverse_up_refs(children: Vec<Arc<RwLock<CacheItem>>>) {
 		loop {
 			let item_ref_copy = Arc::clone(&item_ref);
 			let mut item = item_ref_copy.write().expect("Could not lock item");
-			let root_ = ROOT_A11Y.clone();
-			if matches!(&item.object.id, root_) {
+			let _root = ROOT_A11Y.clone();
+			if matches!(&item.object.id, _root) {
 				break;
 			}
 			item_ref = item.parent_ref().expect("Could not get parent reference");

--- a/cache/benches/load_test.rs
+++ b/cache/benches/load_test.rs
@@ -4,6 +4,8 @@ use std::{
 	time::Duration,
 };
 
+use atspi_connection::AccessibilityConnection;
+use atspi_proxies::accessible::Accessible;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use odilia_cache::{AccessiblePrimitive, Cache, CacheItem};
 
@@ -220,7 +222,7 @@ fn cache_benchmark(c: &mut Criterion) {
 		b.to_async(&rt).iter_batched(
 			|| {
 				children.iter()
-					.map(|am| Arc::clone(&am).read().unwrap().clone())
+					.map(|am| Arc::clone(am).read().unwrap().clone())
 					.collect()
 			},
 			|cs| async { traverse_up(cs).await },

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -6,6 +6,7 @@
 	clippy::unwrap_used,
 	unsafe_code
 )]
+#![allow(clippy::multiple_crate_versions)]
 
 use std::{
 	collections::HashMap,

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1,5 +1,5 @@
 use atspi_common::Granularity;
-use serde::{self, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use zbus::zvariant::OwnedObjectPath;
 
 pub type Accessible = (String, OwnedObjectPath);

--- a/input/src/lib.rs
+++ b/input/src/lib.rs
@@ -6,6 +6,7 @@
 	clippy::unwrap_used,
 	unsafe_code
 )]
+#![allow(clippy::multiple_crate_versions)]
 
 use eyre::Context;
 use nix::unistd::Uid;

--- a/odilia-notify/src/notification.rs
+++ b/odilia-notify/src/notification.rs
@@ -25,8 +25,6 @@ impl TryFrom<Arc<Message>> for Notification {
 }
 #[cfg(test)]
 mod tests {
-	use zbus::names::UniqueName;
-
 	use super::*;
 	#[test]
 	fn correctly_formatted_message_leads_to_a_correct_notification() -> Result<(), zbus::Error>

--- a/tts/src/lib.rs
+++ b/tts/src/lib.rs
@@ -6,6 +6,7 @@
 	clippy::unwrap_used,
 	unsafe_code
 )]
+#![allow(clippy::multiple_crate_versions)]
 
 use eyre::Context;
 use ssip_client_async::{


### PR DESCRIPTION
 fix build instructions in README

It is unnecessary to run `cargo build` before `cargo install`.
On my machine this causes Odilia` to be built twice, possibly because of different
build profiles.

Then the commit/push hooks prevented a push due to a number of compile and `Clippy` issues.
These are addressed in subsequent commits.

