### PR TITLE
Notification improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
           systemctl --user start dbus;
           xvfb-run dunst --screen 0 600x400x8 &
       - name: cargo llvm-cov
-        run: cargo llvm-cov --locked --lcov --output-path lcov.info
+        run: cargo llvm-cov --lcov --output-path lcov.info
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
  "clap 3.2.25",
  "criterion-plot",
  "futures",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -685,7 +685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1210,6 +1210,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,8 +1570,10 @@ name = "odilia-notify"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "itertools 0.12.1",
  "notify-rust",
  "serde",
+ "serde_repr",
  "thiserror",
  "tokio",
  "tracing",

--- a/odilia-notify/Cargo.toml
+++ b/odilia-notify/Cargo.toml
@@ -14,7 +14,9 @@ edition = "2021"
 
 [dependencies]
 futures = "0.3.30"
+itertools = "0.12.1"
 serde.workspace=true
+serde_repr = "0.1.18"
 thiserror = "1.0.56"
 tokio.workspace=true
 tracing.workspace=true

--- a/odilia-notify/src/action.rs
+++ b/odilia-notify/src/action.rs
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Action {
+	pub name: String,
+	pub method: String,
+}

--- a/odilia-notify/src/action.rs
+++ b/odilia-notify/src/action.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Action {
 	pub name: String,
 	pub method: String,

--- a/odilia-notify/src/lib.rs
+++ b/odilia-notify/src/lib.rs
@@ -2,7 +2,9 @@ use futures::{Stream, StreamExt};
 use tracing::{debug, info, instrument};
 
 use zbus::{fdo::MonitoringProxy, Connection, MatchRule, MessageStream, MessageType};
+mod action;
 mod notification;
+mod urgency;
 use notification::Notification;
 mod error;
 use error::NotifyError;

--- a/odilia-notify/src/notification.rs
+++ b/odilia-notify/src/notification.rs
@@ -25,7 +25,6 @@ impl TryFrom<Arc<Message>> for Notification {
 
 	fn try_from(msg: Arc<Message>) -> Result<Self, Self::Error> {
 		let mb: MessageBody = msg.body()?;
-		println!("{mb:?}");
 		let (app_name, _, _, title, body, actions, mut options, _) = mb;
 		let actions = actions
 			.iter()

--- a/odilia-notify/src/notification.rs
+++ b/odilia-notify/src/notification.rs
@@ -4,11 +4,17 @@ use serde::{Deserialize, Serialize};
 
 use zbus::{zvariant::Value, Message};
 
+use crate::action::Action;
+use crate::urgency::Urgency;
+use itertools::Itertools;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Notification {
 	pub app_name: String,
 	pub title: String,
 	pub body: String,
+	pub urgency: Urgency,
+	pub actions: Vec<Action>,
 }
 
 type MessageBody<'a> =
@@ -18,9 +24,25 @@ impl TryFrom<Arc<Message>> for Notification {
 	type Error = zbus::Error;
 
 	fn try_from(msg: Arc<Message>) -> Result<Self, Self::Error> {
-		let (app_name, _, _, title, body, ..) = msg.body::<MessageBody>()?;
+		let mb: MessageBody = msg.body()?;
+		println!("{mb:?}");
+		let (app_name, _, _, title, body, actions, mut options, _) = mb;
+		let actions = actions
+			.iter()
+			.tuples()
+			.map(|(name, method)| Action {
+				name: name.to_string(),
+				method: method.to_string(),
+			})
+			.collect();
+		// any error in deserailizing the value (including lack of "urgency" key in options
+		// hashmap)  will give it an urgency of Normal
+		let urgency = options
+			.remove("urgency")
+			.and_then(|o| o.try_into().ok())
+			.unwrap_or(Urgency::Normal);
 
-		Ok(Notification { app_name, title, body })
+		Ok(Notification { app_name, title, body, actions, urgency })
 	}
 }
 #[cfg(test)]

--- a/odilia-notify/src/notification.rs
+++ b/odilia-notify/src/notification.rs
@@ -8,7 +8,7 @@ use crate::action::Action;
 use crate::urgency::Urgency;
 use itertools::Itertools;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Notification {
 	pub app_name: String,
 	pub title: String,

--- a/odilia-notify/src/urgency.rs
+++ b/odilia-notify/src/urgency.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+use zbus::zvariant::{OwnedValue, Type, Value};
+
+/// A priority/urgency level.
+/// https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html#urgency-levels
+#[derive(Clone, Copy, Debug, Type, Serialize, Deserialize, Default, Value, OwnedValue)]
+#[zvariant(signature = "y")]
+#[repr(u8)]
+pub enum Urgency {
+	Low = 0,
+	#[default]
+	Normal = 1,
+	Critical = 2,
+}

--- a/odilia-notify/src/urgency.rs
+++ b/odilia-notify/src/urgency.rs
@@ -3,7 +3,21 @@ use zbus::zvariant::{OwnedValue, Type, Value};
 
 /// A priority/urgency level.
 /// https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html#urgency-levels
-#[derive(Clone, Copy, Debug, Type, Serialize, Deserialize, Default, Value, OwnedValue)]
+#[derive(
+	Clone,
+	Copy,
+	Debug,
+	Type,
+	Serialize,
+	Deserialize,
+	Default,
+	Value,
+	OwnedValue,
+	Eq,
+	PartialEq,
+	PartialOrd,
+	Ord,
+)]
 #[zvariant(signature = "y")]
 #[repr(u8)]
 pub enum Urgency {


### PR DESCRIPTION
- Add `urgency` field to `Notification` struct
- Add `actions` field to `Notification` struct
- Use `itertools` for chunking vector items by pairs (chunks not available in `std::iter::Iterator` yet)
- Default: `Urgency::Normal`
- No custom `From<T>` for `Value` or `OwnedValue` (all done through `#[derive(...)]`)