### PR TITLE
Allow etc system-wide config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,6 +1520,7 @@ dependencies = [
  "atspi",
  "atspi-client",
  "atspi-common",
+ "atspi-connection",
  "atspi-proxies",
  "criterion",
  "dashmap",

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -37,7 +37,6 @@ pub struct ScreenReaderState {
 	pub cache: Arc<Cache>,
 }
 
-#[derive(Debug)]
 enum ConfigType {
 	CliOverride,
 	XDGConfigHome,

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -1,4 +1,3 @@
-use core::panic;
 use std::{fs, sync::atomic::AtomicI32};
 
 use circular_queue::CircularQueue;
@@ -42,7 +41,7 @@ pub struct ScreenReaderState {
 enum ConfigType {
 	CliOverride,
 	XDGConfigHome,
-	ETC,
+	Etc,
 	CreateDefault,
 }
 
@@ -77,7 +76,7 @@ impl ScreenReaderState {
 		{
 			ConfigType::XDGConfigHome
 		} else if std::path::Path::new("/etc/odilia/config.toml").exists() {
-			ConfigType::ETC
+			ConfigType::Etc
 		} else {
 			ConfigType::CreateDefault
 		};
@@ -92,6 +91,7 @@ impl ScreenReaderState {
 				let xdg_dirs = xdg::BaseDirectories::with_prefix("odilia").expect(
 					"unable to find the odilia config directory according to the xdg dirs specification",
 				);
+
 				let config_path = xdg_dirs.place_config_file("config.toml").expect(
 					"unable to place configuration file. Maybe your system is readonly?",
 				);
@@ -102,7 +102,7 @@ impl ScreenReaderState {
 				}
 				config_path.to_str().ok_or(ConfigError::PathNotFound)?.to_owned()
 			}
-			ConfigType::ETC => "/etc/odilia/config.toml".to_owned(),
+			ConfigType::Etc => "/etc/odilia/config.toml".to_owned(),
 		};
 
 		tracing::debug!(path=%config_path, "loading configuration file");


### PR DESCRIPTION
Addresses https://github.com/odilia-app/odilia/issues/114 

According to Tait's message on Matrix:
> Yes. The issue is that the configuration file is required. In addition, it ignored /etc/odilia/, and only pays attention to $XDG_CONFIG_HOME/odilia/.
I want:
    Odilia to detect configuration files both in /etc/odilia/, and $XDG_CONFIG_HOME/odilia.
    Odilia should work without a configuration file, and it should apply the default config, if a known one is not used.
Obviously, prescience should be for command-line-flag (if given), followed by XDG_CONFIG_HOME, followed by /etc/odilia/ followed by "use the default, whatever that is".

This PR should support configuration in /etc/. It is cleaner than the old config code by using enums and matching. It prioritizes the order Tait gave. 

To be clear, if there is no config in either XDG or etc, Odilia will still launch (This was the case even before this PR, if the XDG config didn't exist, it would still launch), but now a new config will not be created if there is an existing config file in the systemwide /etc/odilia/config.toml file and it will default to that if the user config is not set

Before this PR I ran
- [x] cargo fmt
- [x] cargo check
- [x] cargo clippy