### PR TITLE
make configuration handling a lot better

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,15 +975,13 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "figment"
-version = "0.10.14"
+version = "0.10.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b6e5bc7bd59d60d0d45a6ccab6cf0f4ce28698fb4e81e750ddf229c9b824026"
+checksum = "7270677e7067213e04f323b55084586195f18308cd7546cfac9f873344ccceb6"
 dependencies = [
  "atomic",
- "parking_lot",
  "pear",
  "serde",
- "tempfile",
  "toml",
  "uncased",
  "version_check",
@@ -1550,6 +1548,7 @@ dependencies = [
  "circular-queue",
  "clap 4.5.2",
  "eyre",
+ "figment",
  "futures",
  "lazy_static",
  "odilia-cache",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,6 +1563,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
+ "toml",
  "tracing",
  "tracing-error",
  "tracing-log",
@@ -2456,9 +2457,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+checksum = "af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e"
 dependencies = [
  "serde",
  "serde_spanned",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,7 +1565,8 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-error",
- "tracing-log",
+ "tracing-journald",
+ "tracing-log 0.1.4",
  "tracing-subscriber",
  "tracing-tree",
  "xdg",
@@ -2542,10 +2543,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-journald"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba316a74e8fc3c3896a850dba2375928a9fa171b085ecddfc7c054d39970f3fd"
+dependencies = [
+ "libc",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
@@ -2559,13 +2582,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "parking_lot",
  "regex",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log 0.2.0",
 ]
 
 [[package]]
@@ -2576,7 +2602,7 @@ checksum = "2ec6adcab41b1391b08a308cc6302b79f8095d1673f6947c2dc65ffb028b0b2d"
 dependencies = [
  "nu-ansi-term",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.1.4",
  "tracing-subscriber",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +519,12 @@ name = "bumpalo"
 version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+
+[[package]]
+name = "bytemuck"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 
 [[package]]
 name = "byteorder"
@@ -959,6 +974,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "figment"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6e5bc7bd59d60d0d45a6ccab6cf0f4ce28698fb4e81e750ddf229c9b824026"
+dependencies = [
+ "atomic",
+ "parking_lot",
+ "pear",
+ "serde",
+ "tempfile",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,6 +1232,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
 ]
+
+[[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "instant"
@@ -1566,11 +1603,11 @@ dependencies = [
  "atspi",
  "atspi-common",
  "bitflags 1.3.2",
+ "figment",
  "serde",
  "serde_plain",
  "smartstring",
  "thiserror",
- "tini",
  "zbus",
 ]
 
@@ -1680,6 +1717,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pear"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccca0f6c17acc81df8e242ed473ec144cbf5c98037e69aa6d144780aad103c8"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e22670e8eb757cff11d6c199ca7b987f352f0346e0be4dd23869ec72cb53c77"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,7 +1839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -1789,6 +1849,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -2047,6 +2120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,12 +2376,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
-name = "tini"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004df4c5f0805eb5f55883204a514cfa43a6d924741be29e871753a53d5565a"
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2379,10 +2455,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.7",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -2392,7 +2483,20 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.2.5",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
+dependencies = [
+ "indexmap 2.2.5",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.5",
 ]
 
 [[package]]
@@ -2491,6 +2595,15 @@ dependencies = [
  "memoffset 0.9.0",
  "tempfile",
  "winapi",
+]
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -2813,6 +2926,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "xdg"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2833,6 +2955,12 @@ name = "xml-rs"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zbus"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -20,4 +20,4 @@ smartstring = "1.0.1"
 thiserror = "1.0.37"
 zbus.workspace = true
 serde_plain.workspace = true
-figment = { version = "0.10.14", features = ["toml", "test", "env"] }
+figment = "0.10.15"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,6 +18,6 @@ bitflags = "1.3.2"
 serde = "1.0.147"
 smartstring = "1.0.1"
 thiserror = "1.0.37"
-tini = "^1.3.0"
 zbus.workspace = true
 serde_plain.workspace = true
+figment = { version = "0.10.14", features = ["toml", "test", "env"] }

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -23,19 +23,19 @@ pub enum OdiliaError {
 }
 #[derive(Debug)]
 pub enum ConfigError {
-	Tini(tini::Error),
+	Figment(figment::Error),
 	ValueNotFound,
 	PathNotFound,
 }
-impl From<tini::Error> for ConfigError {
-	fn from(t_err: tini::Error) -> Self {
-		Self::Tini(t_err)
+impl From<figment::Error> for ConfigError {
+	fn from(t_err: figment::Error) -> Self {
+		Self::Figment(t_err)
 	}
 }
 impl std::fmt::Display for ConfigError {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
-			Self::Tini(t) => t.fmt(f),
+			Self::Figment(t) => t.fmt(f),
 			Self::ValueNotFound => f.write_str("Vlaue not found in config file."),
 			Self::PathNotFound => {
 				f.write_str("The path for the config file was not found.")

--- a/common/src/settings/log.rs
+++ b/common/src/settings/log.rs
@@ -16,7 +16,10 @@ pub struct LogSettings {
 }
 impl Default for LogSettings {
 	fn default() -> Self {
-		Self { level: "info".to_owned(), logger: LoggingKind::File("/var/log/odilia.log".into()) }
+		Self {
+			level: "info".to_owned(),
+			logger: LoggingKind::File("/var/log/odilia.log".into()),
+		}
 	}
 }
 

--- a/common/src/settings/log.rs
+++ b/common/src/settings/log.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 pub struct LogSettings {
 	level: String,
 }
-impl LogSettings {
-	pub fn new(level: String) -> Self {
-		Self { level }
+impl Default for LogSettings {
+	fn default() -> Self {
+		Self { level: "info".to_owned() }
 	}
 }

--- a/common/src/settings/log.rs
+++ b/common/src/settings/log.rs
@@ -1,12 +1,35 @@
+use std::path::PathBuf;
+
 use serde::{Deserialize, Serialize};
 ///structure used for all the configurable options related to logging
 #[derive(Debug, Serialize, Deserialize)]
 #[allow(clippy::module_name_repetitions)]
 pub struct LogSettings {
-	level: String,
+	///the logging level this session should output at
+	/// see the tracing documentation for more information, in the log filters section
+	/// typical values here include info, warn, debug and trace
+	/// however, one can also include specific modules for which logging should be shown at a different warning level
+	pub level: String,
+	///the place where odilia should output its logs
+	/// the values possible include tty, file and syslog
+	pub logger: LoggingKind,
 }
 impl Default for LogSettings {
 	fn default() -> Self {
-		Self { level: "info".to_owned() }
+		Self { level: "info".to_owned(), logger: LoggingKind::File("/var/log/odilia.log".into()) }
 	}
+}
+
+///the place where odilia should output its logs
+#[derive(Serialize, Deserialize, Debug)]
+pub enum LoggingKind {
+	///a file where the log messages should be written
+	/// the path can be both absolute and relative to the current working directory
+	/// warning: the path must be accessible permission wise from the user where odilia was launched
+	File(PathBuf),
+	///logs are being sent to the terminal directly
+	Tty,
+	///the logs are sent to systemd-journald, as long as the target architecture supports it
+	/// if that's not the case, this option does nothing
+	Syslog,
 }

--- a/common/src/settings/mod.rs
+++ b/common/src/settings/mod.rs
@@ -11,18 +11,7 @@ use serde::{Deserialize, Serialize};
 /// the only way this config should change is if the configuration file changes, in which case the entire view will be replaced to reflect the fact
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct ApplicationConfig {
-	speech: SpeechSettings,
-	log: LogSettings,
+	pub speech: SpeechSettings,
+	pub log: LogSettings,
 }
 
-impl ApplicationConfig {
-	#[must_use]
-	pub fn log(&self) -> &LogSettings {
-		&self.log
-	}
-
-	#[must_use]
-	pub fn speech(&self) -> &SpeechSettings {
-		&self.speech
-	}
-}

--- a/common/src/settings/mod.rs
+++ b/common/src/settings/mod.rs
@@ -6,13 +6,6 @@ use speech::SpeechSettings;
 
 use serde::{Deserialize, Serialize};
 
-use figment::{
-	providers::{Env, Format, Serialized, Toml},
-	Figment,
-};
-
-use crate::errors::ConfigError;
-
 ///type representing a *read-only* view of the odilia screenreader configuration
 /// this type should only be obtained as a result of parsing odilia's configuration files, as it containes types for each section responsible for controlling various parts of the screenreader
 /// the only way this config should change is if the configuration file changes, in which case the entire view will be replaced to reflect the fact
@@ -23,20 +16,6 @@ pub struct ApplicationConfig {
 }
 
 impl ApplicationConfig {
-	/// Opens a new config file with a certain path.
-	///
-	/// # Errors
-	///
-	/// This can return `Err(_)` if the path doesn't exist, or if not all the key/value pairs are defined.
-	pub fn new(path: &str) -> Result<Self, ConfigError> {
-		let config: Self =
-			Figment::from(Serialized::defaults(ApplicationConfig::default()))
-				.merge(Toml::file(path))
-				.merge(Env::prefixed("ODILIA_"))
-				.extract()?;
-		Ok(config)
-	}
-
 	#[must_use]
 	pub fn log(&self) -> &LogSettings {
 		&self.log

--- a/common/src/settings/mod.rs
+++ b/common/src/settings/mod.rs
@@ -14,4 +14,3 @@ pub struct ApplicationConfig {
 	pub speech: SpeechSettings,
 	pub log: LogSettings,
 }
-

--- a/common/src/settings/mod.rs
+++ b/common/src/settings/mod.rs
@@ -1,5 +1,5 @@
-mod log;
-mod speech;
+pub mod log;
+pub mod speech;
 
 use log::LogSettings;
 use speech::SpeechSettings;

--- a/common/src/settings/mod.rs
+++ b/common/src/settings/mod.rs
@@ -1,17 +1,22 @@
 mod log;
 mod speech;
+
 use log::LogSettings;
 use speech::SpeechSettings;
 
 use serde::{Deserialize, Serialize};
-use tini::Ini;
+
+use figment::{
+	providers::{Env, Format, Serialized, Toml},
+	Figment,
+};
 
 use crate::errors::ConfigError;
 
 ///type representing a *read-only* view of the odilia screenreader configuration
 /// this type should only be obtained as a result of parsing odilia's configuration files, as it containes types for each section responsible for controlling various parts of the screenreader
 /// the only way this config should change is if the configuration file changes, in which case the entire view will be replaced to reflect the fact
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct ApplicationConfig {
 	speech: SpeechSettings,
 	log: LogSettings,
@@ -24,12 +29,12 @@ impl ApplicationConfig {
 	///
 	/// This can return `Err(_)` if the path doesn't exist, or if not all the key/value pairs are defined.
 	pub fn new(path: &str) -> Result<Self, ConfigError> {
-		let ini = Ini::from_file(path)?;
-		let rate: i32 = ini.get("speech", "rate").ok_or(ConfigError::ValueNotFound)?;
-		let level: String = ini.get("log", "level").ok_or(ConfigError::ValueNotFound)?;
-		let speech = SpeechSettings::new(rate);
-		let log = LogSettings::new(level);
-		Ok(Self { speech, log })
+		let config: Self =
+			Figment::from(Serialized::defaults(ApplicationConfig::default()))
+				.merge(Toml::file(path))
+				.merge(Env::prefixed("ODILIA_"))
+				.extract()?;
+		Ok(config)
 	}
 
 	#[must_use]

--- a/common/src/settings/speech.rs
+++ b/common/src/settings/speech.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize)]
 #[allow(clippy::module_name_repetitions)]
 pub struct SpeechSettings {
-	pub rate: i32,
+	pub rate: i8,
 }
 impl Default for SpeechSettings {
 	fn default() -> Self {

--- a/common/src/settings/speech.rs
+++ b/common/src/settings/speech.rs
@@ -6,9 +6,10 @@ pub struct SpeechSettings {
 	pub rate: i8,
 	pub pitch: i8,
 	pub volume: i8,
+	pub module: String,
 }
 impl Default for SpeechSettings {
 	fn default() -> Self {
-		Self { rate: 50, pitch: 0, volume: 100}
+		Self { rate: 50, pitch: 0, volume: 100, module: "espeak-ng".into()}
 	}
 }

--- a/common/src/settings/speech.rs
+++ b/common/src/settings/speech.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 pub struct SpeechSettings {
 	pub rate: i32,
 }
-impl SpeechSettings {
-	pub fn new(rate: i32) -> Self {
-		Self { rate }
+impl Default for SpeechSettings {
+	fn default() -> Self {
+		Self { rate: 50 }
 	}
 }

--- a/common/src/settings/speech.rs
+++ b/common/src/settings/speech.rs
@@ -7,9 +7,11 @@ pub struct SpeechSettings {
 	pub pitch: i8,
 	pub volume: i8,
 	pub module: String,
+	pub language: String,
+	pub person: String,
 }
 impl Default for SpeechSettings {
 	fn default() -> Self {
-		Self { rate: 50, pitch: 0, volume: 100, module: "espeak-ng".into()}
+		Self { rate: 50, pitch: 0, volume: 100, module: "espeak-ng".into(), language: "en-US".into(), person: "English (America)+Max".into()}
 	}
 }

--- a/common/src/settings/speech.rs
+++ b/common/src/settings/speech.rs
@@ -4,9 +4,10 @@ use serde::{Deserialize, Serialize};
 #[allow(clippy::module_name_repetitions)]
 pub struct SpeechSettings {
 	pub rate: i8,
+	pub pitch: i8,
 }
 impl Default for SpeechSettings {
 	fn default() -> Self {
-		Self { rate: 50 }
+		Self { rate: 50, pitch: 0}
 	}
 }

--- a/common/src/settings/speech.rs
+++ b/common/src/settings/speech.rs
@@ -9,9 +9,18 @@ pub struct SpeechSettings {
 	pub module: String,
 	pub language: String,
 	pub person: String,
+	pub punctuation: PunctuationSpellingMode,
 }
 impl Default for SpeechSettings {
 	fn default() -> Self {
-		Self { rate: 50, pitch: 0, volume: 100, module: "espeak-ng".into(), language: "en-US".into(), person: "English (America)+Max".into()}
+		Self { rate: 50, pitch: 0, volume: 100, module: "espeak-ng".into(), language: "en-US".into(), person: "English (America)+Max".into(), punctuation: PunctuationSpellingMode::Some}
 	}
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub enum PunctuationSpellingMode{
+	Some,
+	Most,
+	None,
+	All,
 }

--- a/common/src/settings/speech.rs
+++ b/common/src/settings/speech.rs
@@ -5,9 +5,10 @@ use serde::{Deserialize, Serialize};
 pub struct SpeechSettings {
 	pub rate: i8,
 	pub pitch: i8,
+	pub volume: i8,
 }
 impl Default for SpeechSettings {
 	fn default() -> Self {
-		Self { rate: 50, pitch: 0}
+		Self { rate: 50, pitch: 0, volume: 100}
 	}
 }

--- a/common/src/settings/speech.rs
+++ b/common/src/settings/speech.rs
@@ -13,12 +13,20 @@ pub struct SpeechSettings {
 }
 impl Default for SpeechSettings {
 	fn default() -> Self {
-		Self { rate: 50, pitch: 0, volume: 100, module: "espeak-ng".into(), language: "en-US".into(), person: "English (America)+Max".into(), punctuation: PunctuationSpellingMode::Some}
+		Self {
+			rate: 50,
+			pitch: 0,
+			volume: 100,
+			module: "espeak-ng".into(),
+			language: "en-US".into(),
+			person: "English (America)+Max".into(),
+			punctuation: PunctuationSpellingMode::Some,
+		}
 	}
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
-pub enum PunctuationSpellingMode{
+pub enum PunctuationSpellingMode {
 	Some,
 	Most,
 	None,

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -58,6 +58,7 @@ clap = { version = "4.5.1", features = ["derive"] }
 tokio-util.workspace=true
 toml = "0.8.11"
 figment = { version = "0.10.14", features = ["env", "toml"] }
+tracing-journald = "0.3.0"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -57,6 +57,7 @@ odilia-notify = { version = "0.1.0", path = "../odilia-notify" }
 clap = { version = "4.5.1", features = ["derive"] }
 tokio-util.workspace=true
 toml = "0.8.11"
+figment = { version = "0.10.14", features = ["env", "toml"] }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -56,6 +56,7 @@ zbus.workspace = true
 odilia-notify = { version = "0.1.0", path = "../odilia-notify" }
 clap = { version = "4.5.1", features = ["derive"] }
 tokio-util.workspace=true
+toml = "0.8.11"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/odilia/src/events/mod.rs
+++ b/odilia/src/events/mod.rs
@@ -196,6 +196,7 @@ async fn dispatch(state: &ScreenReaderState, event: Event) -> eyre::Result<()> {
 pub mod dispatch_tests {
 	use crate::ScreenReaderState;
 	use eyre::Context;
+	use odilia_common::settings::ApplicationConfig;
 	use tokio::sync::mpsc::channel;
 
 	#[tokio::test]
@@ -209,7 +210,7 @@ pub mod dispatch_tests {
 		let (send, _recv) = channel(32);
 		let cache = serde_json::from_str(include_str!("wcag_cache_items.json"))
 			.context("unable to load cache data from json file")?;
-		let state = ScreenReaderState::new(send, None)
+		let state = ScreenReaderState::new(send, ApplicationConfig::default())
 			.await
 			.context("unable to realise screenreader state")?;
 		state.cache

--- a/odilia/src/logging.rs
+++ b/odilia/src/logging.rs
@@ -5,7 +5,8 @@
 
 use std::env;
 
-use odilia_common::settings::ApplicationConfig;
+use eyre::Context;
+use odilia_common::settings::{log::LoggingKind, ApplicationConfig};
 use tracing_error::ErrorLayer;
 use tracing_log::LogTracer;
 use tracing_subscriber::{prelude::*, EnvFilter};
@@ -13,29 +14,48 @@ use tracing_tree::HierarchicalLayer;
 
 /// Initialise the logging stack
 /// this requires an application configuration structure, so configuration must be initialized before logging is
-pub fn init(config:&ApplicationConfig) {
-	let env_filter = match env::var("ODILIA_LOG").or_else(|_| env::var("RUST_LOG")) {
-		Ok(s) => EnvFilter::from(s),
-		Err(env::VarError::NotPresent) => EnvFilter::from(&config.log.level),
-		Err(e) => {
-			eprintln!("Warning: Failed to read log filter from ODILIA_LOG or RUST_LOG: {e}");
-			EnvFilter::from(&config.log.level)
+pub fn init(config: &ApplicationConfig) -> eyre::Result<()> {
+	let env_filter =
+		match env::var("APP_LOG").or_else(|_| env::var("RUST_LOG")) {
+			Ok(s) => EnvFilter::from(s),
+			Err(env::VarError::NotPresent) => EnvFilter::from(&config.log.level),
+			Err(e) => {
+				eprintln!("Warning: Failed to read log filter from APP_LOG or RUST_LOG: {e}");
+				EnvFilter::from(&config.log.level)
+			}
+		};
+	//this requires boxing because the types returned by this match block would be incompatible otherwise, since we return different layers depending on what we get from the configuration. It is possible to do it otherwise, hopefully, but for now this and a forced dereference at the end would do
+	let output_layer = match &config.log.logger {
+		LoggingKind::File(path) => {
+			let file = std::fs::File::options()
+				.create_new(true)
+				.write(true)
+				.open(path)
+				.with_context(|| {
+					format!("creating log file '{}'", path.display())
+				})?;
+			let fmt =
+				tracing_subscriber::fmt::layer().with_ansi(false).with_writer(file);
+			fmt.boxed()
 		}
+		LoggingKind::Tty => tracing_subscriber::fmt::layer()
+			.with_ansi(true)
+			.with_target(true)
+			.boxed(),
+		LoggingKind::Syslog => tracing_journald::layer()?.boxed(),
 	};
 	let subscriber = tracing_subscriber::Registry::default()
 		.with(env_filter)
+		.with(output_layer)
 		.with(ErrorLayer::default())
 		.with(HierarchicalLayer::new(4)
-			.with_ansi(true)
 			.with_bracketed_fields(true)
 			.with_targets(true)
 			.with_deferred_spans(true)
 			.with_span_retrace(true)
 			.with_indent_lines(true));
-	if let Err(e) = tracing::subscriber::set_global_default(subscriber) {
-		eprintln!("Warning: Failed to set log handler: {e}");
-	}
-	if let Err(e) = LogTracer::init() {
-		tracing::warn!(error = %e, "Failed to install log facade");
-	}
+	tracing::subscriber::set_global_default(subscriber)
+		.wrap_err("unable to init default logging layer")?;
+	LogTracer::init().wrap_err("unable to init tracing log layer")?;
+	Ok(())
 }

--- a/odilia/src/logging.rs
+++ b/odilia/src/logging.rs
@@ -5,24 +5,21 @@
 
 use std::env;
 
+use odilia_common::settings::ApplicationConfig;
 use tracing_error::ErrorLayer;
 use tracing_log::LogTracer;
 use tracing_subscriber::{prelude::*, EnvFilter};
 use tracing_tree::HierarchicalLayer;
 
-#[cfg(not(debug_assertions))]
-const DEFAULT_LOG_FILTER: &str = "none";
-#[cfg(debug_assertions)]
-const DEFAULT_LOG_FILTER: &str = "debug";
-
-/// Initialise the logging stack.
-pub fn init() {
+/// Initialise the logging stack
+/// this requires an application configuration structure, so configuration must be initialized before logging is
+pub fn init(config:&ApplicationConfig) {
 	let env_filter = match env::var("ODILIA_LOG").or_else(|_| env::var("RUST_LOG")) {
 		Ok(s) => EnvFilter::from(s),
-		Err(env::VarError::NotPresent) => EnvFilter::from(DEFAULT_LOG_FILTER),
+		Err(env::VarError::NotPresent) => EnvFilter::from(&config.log.level),
 		Err(e) => {
 			eprintln!("Warning: Failed to read log filter from ODILIA_LOG or RUST_LOG: {e}");
-			EnvFilter::from(DEFAULT_LOG_FILTER)
+			EnvFilter::from(&config.log.level)
 		}
 	};
 	let subscriber = tracing_subscriber::Registry::default()

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -82,7 +82,6 @@ async fn sigterm_signal_watcher(
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> eyre::Result<()> {
 	let args = Args::parse();
-	logging::init();
 
 	//initialize the primary token for task cancelation
 	let token = CancellationToken::new();
@@ -90,9 +89,12 @@ async fn main() -> eyre::Result<()> {
 	//initialize a task tracker, which will allow us to wait for all tasks to finish
 	let tracker = TaskTracker::new();
 
-	tracing::debug!("Reading configuration");
+	//initializing configuration
 	let config = load_configuration(args.config)?;
-	tracing::debug!(?config, "configuration loaded successfully");
+	//initialize logging, with the provided config
+	logging::init(&config);
+
+	tracing::info!(?config, "this configuration was used to prepair odilia");
 
 	// Make sure applications with dynamic accessibility support do expose their AT-SPI2 interfaces.
 	if let Err(e) = atspi_connection::set_session_accessibility(true)

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -162,12 +162,10 @@ async fn main() -> eyre::Result<()> {
 }
 
 fn load_configuration(cli_overide: Option<PathBuf>) -> Result<ApplicationConfig, eyre::Report> {
-	// In order, do environment variables, a configuration file specified via cli, XDG_CONFIG_HOME, the usual location for system wide configuration(/etc/odilia/config.toml)
+	// In order, do  a configuration file specified via cli, XDG_CONFIG_HOME, the usual location for system wide configuration(/etc/odilia/config.toml)
 	// If XDG_CONFIG_HOME based configuration wasn't found, create one with default values for the user to alter, for the next run of odilia
 	//default configuration first, because that doesn't affect the priority outlined above
-	let figment = Figment::from(Serialized::defaults(ApplicationConfig::default()))
-		//environment variables
-		.join(Env::prefixed("ODILIA_").split("_"));
+	let figment = Figment::from(Serialized::defaults(ApplicationConfig::default()));
 	//cli override, if applicable
 	let figment =
 		if let Some(path) = cli_overide { figment.join(Toml::file(path)) } else { figment };

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> eyre::Result<()> {
 	//initializing configuration
 	let config = load_configuration(args.config)?;
 	//initialize logging, with the provided config
-	logging::init(&config);
+	logging::init(&config)?;
 
 	tracing::info!(?config, "this configuration was used to prepair odilia");
 

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -20,7 +20,7 @@ use crate::state::ScreenReaderState;
 use clap::Parser;
 use eyre::WrapErr;
 use figment::{
-	providers::{Env, Format, Serialized, Toml},
+	providers::{Format, Serialized, Toml},
 	Figment,
 };
 use futures::{future::FutureExt, StreamExt};

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -13,13 +13,18 @@ mod events;
 mod logging;
 mod state;
 
-use std::{process::exit, sync::Arc, time::Duration};
+use std::{fs, process::exit, sync::Arc, time::Duration};
 
 use crate::cli::Args;
 use crate::state::ScreenReaderState;
 use clap::Parser;
 use eyre::WrapErr;
+use figment::{
+	providers::{Env, Format, Serialized, Toml},
+	Figment,
+};
 use futures::{future::FutureExt, StreamExt};
+use odilia_common::settings::ApplicationConfig;
 use odilia_input::sr_event_receiver;
 use odilia_notify::listen_to_dbus_notifications;
 use ssip_client_async::Priority;
@@ -85,6 +90,42 @@ async fn main() -> eyre::Result<()> {
 	//initialize a task tracker, which will allow us to wait for all tasks to finish
 	let tracker = TaskTracker::new();
 
+	tracing::debug!("Reading configuration");
+
+	// In order of prioritization, do environment variables, configuration via cli, then XDG_CONFIG_HOME, then /etc/odilia,
+	// Otherwise create it in XDG_CONFIG_HOME
+	//default configuration first, because that doesn't affect the priority outlined above
+	let figment = Figment::from(Serialized::defaults(ApplicationConfig::default()));
+	//environment variables
+	let figment = figment.merge(Env::prefixed("ODILIA_"));
+	//cli override, if applicable
+	let figment = if let Some(path) = args.config {
+		figment.merge(Toml::file(path))
+	} else {
+		figment
+	};
+	//create a config.toml file in `XDG_CONFIG_HOME`, to make it possible for the user to edit the default values, if it doesn't exist already
+	let xdg_dirs = xdg::BaseDirectories::with_prefix("odilia").expect(
+			"unable to find the odilia config directory according to the xdg dirs specification",
+		);
+
+	let config_path = xdg_dirs
+		.place_config_file("config.toml")
+		.expect("unable to place configuration file. Maybe your system is readonly?");
+
+	if !config_path.exists() {
+		let toml = toml::to_string(&ApplicationConfig::default())?;
+		fs::write(&config_path, toml).expect("Unable to create default config file.");
+	}
+	//next, the xdg configuration
+	let figment = figment
+		.merge(Toml::file(&config_path))
+		//last, the configuration system wide, in /etc/odilia/config.toml
+		.merge(Toml::file("/etc/odilia/config.toml"));
+	//realise the configuration and freeze it into place
+	let config: ApplicationConfig = figment.extract()?;
+	tracing::debug!("configuration loaded successfully");
+
 	// Make sure applications with dynamic accessibility support do expose their AT-SPI2 interfaces.
 	if let Err(e) = atspi_connection::set_session_accessibility(true)
 		.instrument(tracing::info_span!("setting accessibility enabled flag"))
@@ -101,7 +142,7 @@ async fn main() -> eyre::Result<()> {
 	// Like the channel above, it is very important that this is *never* full, since it can cause deadlocking if the other task sending the request is working with zbus.
 	let (ssip_req_tx, ssip_req_rx) = mpsc::channel::<ssip_client_async::Request>(128);
 	// Initialize state
-	let state = Arc::new(ScreenReaderState::new(ssip_req_tx, args.config.as_deref()).await?);
+	let state = Arc::new(ScreenReaderState::new(ssip_req_tx, config).await?);
 	let ssip = odilia_tts::create_ssip_client().await?;
 
 	if state.say(Priority::Message, "Welcome to Odilia!".to_string()).await {

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -96,14 +96,11 @@ async fn main() -> eyre::Result<()> {
 	// Otherwise create it in XDG_CONFIG_HOME
 	//default configuration first, because that doesn't affect the priority outlined above
 	let figment = Figment::from(Serialized::defaults(ApplicationConfig::default()))
-	//environment variables
-	.join(Env::prefixed("ODILIA_"));
+		//environment variables
+		.join(Env::prefixed("ODILIA_").split("_"));
 	//cli override, if applicable
-	let figment = if let Some(path) = args.config {
-		figment.join(Toml::file(path))
-	} else {
-		figment
-	};
+	let figment =
+		if let Some(path) = args.config { figment.join(Toml::file(path)) } else { figment };
 	//create a config.toml file in `XDG_CONFIG_HOME`, to make it possible for the user to edit the default values, if it doesn't exist already
 	let xdg_dirs = xdg::BaseDirectories::with_prefix("odilia").expect(
 			"unable to find the odilia config directory according to the xdg dirs specification",

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -184,9 +184,9 @@ fn load_configuration(cli_overide: Option<PathBuf>) -> Result<ApplicationConfig,
 	}
 	//next, the xdg configuration
 	let figment = figment
-		.join(Toml::file(&config_path))
+		.admerge(Toml::file(&config_path))
 		//last, the configuration system wide, in /etc/odilia/config.toml
-		.join(Toml::file("/etc/odilia/config.toml"));
+		.admerge(Toml::file("/etc/odilia/config.toml"));
 	//realise the configuration and freeze it into place
 	Ok(figment.extract()?)
 }

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -100,7 +100,8 @@ impl ScreenReaderState {
 				);
 
 				if !config_path.exists() {
-					fs::write(&config_path, include_str!("../config.toml"))
+					let toml = toml::to_string(&ApplicationConfig::default())?;
+					fs::write(&config_path, toml)
 						.expect("Unable to copy default config file.");
 				}
 				config_path.to_str().ok_or(ConfigError::PathNotFound)?.to_owned()

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::AtomicI32;
 
 use circular_queue::CircularQueue;
 use eyre::WrapErr;
-use ssip_client_async::{MessageScope, Priority, Request as SSIPRequest};
+use ssip_client_async::{MessageScope, Priority, PunctuationMode, Request as SSIPRequest};
 use tokio::sync::{mpsc::Sender, Mutex};
 use tracing::{debug, Instrument};
 use zbus::{fdo::DBusProxy, names::UniqueName, zvariant::ObjectPath, MatchRule, MessageType};
@@ -16,7 +16,7 @@ use atspi_connection::AccessibilityConnection;
 use atspi_proxies::{accessible::AccessibleProxy, cache::CacheProxy};
 use odilia_cache::{AccessiblePrimitive, Cache, CacheItem};
 use odilia_common::{
-	errors::CacheError, modes::ScreenReaderMode, settings::ApplicationConfig,
+	errors::CacheError, modes::ScreenReaderMode, settings::{speech::PunctuationSpellingMode, ApplicationConfig},
 	types::TextSelectionArea, Result as OdiliaResult,
 };
 use std::sync::Arc;
@@ -82,6 +82,14 @@ impl ScreenReaderState {
 			config.speech.person.clone(),
 		))
 		.await?;
+		//doing it this way for now. It could have been done with a From impl, but I don't want to make ssip_client_async a dependency of odilia_common, so this conversion is done directly inside state, especially since this enum isn't supposed to grow any further, in complexity or variants
+		let punctuation_mode=match config.speech.punctuation{
+			PunctuationSpellingMode::Some => PunctuationMode::Some,
+			PunctuationSpellingMode::Most => PunctuationMode::Most,
+			PunctuationSpellingMode::None => PunctuationMode::None,
+			PunctuationSpellingMode::All => PunctuationMode::All,
+		};
+		ssip.send(SSIPRequest::SetPunctuationMode(ssip_client_async::ClientScope::Current, punctuation_mode)).await?;
 		ssip.send(SSIPRequest::SetRate(
 			ssip_client_async::ClientScope::Current,
 			config.speech.rate,

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -72,6 +72,16 @@ impl ScreenReaderState {
 			config.speech.module.clone(),
 		))
 		.await?;
+		ssip.send(SSIPRequest::SetLanguage(
+			ssip_client_async::ClientScope::Current,
+			config.speech.language.clone(),
+		))
+		.await?;
+		ssip.send(SSIPRequest::SetSynthesisVoice(
+			ssip_client_async::ClientScope::Current,
+			config.speech.person.clone(),
+		))
+		.await?;
 		ssip.send(SSIPRequest::SetRate(
 			ssip_client_async::ClientScope::Current,
 			config.speech.rate,

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -57,7 +57,7 @@ impl ScreenReaderState {
 		let accessible_history = Mutex::new(CircularQueue::with_capacity(16));
 		let event_history = Mutex::new(CircularQueue::with_capacity(16));
 		let cache = Arc::new(Cache::new(atspi.connection().clone()));
-
+ssip.send(SSIPRequest::SetRate(ssip_client_async::ClientScope::Current, config.speech().rate)).await?;
 		Ok(Self {
 			atspi,
 			dbus,

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -57,7 +57,11 @@ impl ScreenReaderState {
 		let accessible_history = Mutex::new(CircularQueue::with_capacity(16));
 		let event_history = Mutex::new(CircularQueue::with_capacity(16));
 		let cache = Arc::new(Cache::new(atspi.connection().clone()));
-ssip.send(SSIPRequest::SetRate(ssip_client_async::ClientScope::Current, config.speech().rate)).await?;
+		ssip.send(SSIPRequest::SetRate(
+			ssip_client_async::ClientScope::Current,
+			config.speech().rate,
+		))
+		.await?;
 		Ok(Self {
 			atspi,
 			dbus,

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -57,9 +57,21 @@ impl ScreenReaderState {
 		let accessible_history = Mutex::new(CircularQueue::with_capacity(16));
 		let event_history = Mutex::new(CircularQueue::with_capacity(16));
 		let cache = Arc::new(Cache::new(atspi.connection().clone()));
-		ssip.send(SSIPRequest::SetPitch(ssip_client_async::ClientScope::Current, config.speech.pitch)).await?;
-		ssip.send(SSIPRequest::SetVolume(ssip_client_async::ClientScope::Current, config.speech.volume)).await?;
-		
+		ssip.send(SSIPRequest::SetPitch(
+			ssip_client_async::ClientScope::Current,
+			config.speech.pitch,
+		))
+		.await?;
+		ssip.send(SSIPRequest::SetVolume(
+			ssip_client_async::ClientScope::Current,
+			config.speech.volume,
+		))
+		.await?;
+		ssip.send(SSIPRequest::SetOutputModule(
+			ssip_client_async::ClientScope::Current,
+			config.speech.module.clone(),
+		))
+		.await?;
 		ssip.send(SSIPRequest::SetRate(
 			ssip_client_async::ClientScope::Current,
 			config.speech.rate,

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -59,7 +59,7 @@ impl ScreenReaderState {
 		let cache = Arc::new(Cache::new(atspi.connection().clone()));
 		ssip.send(SSIPRequest::SetRate(
 			ssip_client_async::ClientScope::Current,
-			config.speech().rate,
+			config.speech.rate,
 		))
 		.await?;
 		Ok(Self {

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -57,7 +57,9 @@ impl ScreenReaderState {
 		let accessible_history = Mutex::new(CircularQueue::with_capacity(16));
 		let event_history = Mutex::new(CircularQueue::with_capacity(16));
 		let cache = Arc::new(Cache::new(atspi.connection().clone()));
-		ssip.send(SSIPRequest::SetPitch(ssip_client_async::ClientScope::Current, config.speech.pitch)).await?s;
+		ssip.send(SSIPRequest::SetPitch(ssip_client_async::ClientScope::Current, config.speech.pitch)).await?;
+		ssip.send(SSIPRequest::SetVolume(ssip_client_async::ClientScope::Current, config.speech.volume)).await?;
+		
 		ssip.send(SSIPRequest::SetRate(
 			ssip_client_async::ClientScope::Current,
 			config.speech.rate,

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -57,6 +57,7 @@ impl ScreenReaderState {
 		let accessible_history = Mutex::new(CircularQueue::with_capacity(16));
 		let event_history = Mutex::new(CircularQueue::with_capacity(16));
 		let cache = Arc::new(Cache::new(atspi.connection().clone()));
+		ssip.send(SSIPRequest::SetPitch(ssip_client_async::ClientScope::Current, config.speech.pitch)).await?s;
 		ssip.send(SSIPRequest::SetRate(
 			ssip_client_async::ClientScope::Current,
 			config.speech.rate,

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -16,8 +16,11 @@ use atspi_connection::AccessibilityConnection;
 use atspi_proxies::{accessible::AccessibleProxy, cache::CacheProxy};
 use odilia_cache::{AccessiblePrimitive, Cache, CacheItem};
 use odilia_common::{
-	errors::CacheError, modes::ScreenReaderMode, settings::{speech::PunctuationSpellingMode, ApplicationConfig},
-	types::TextSelectionArea, Result as OdiliaResult,
+	errors::CacheError,
+	modes::ScreenReaderMode,
+	settings::{speech::PunctuationSpellingMode, ApplicationConfig},
+	types::TextSelectionArea,
+	Result as OdiliaResult,
 };
 use std::sync::Arc;
 
@@ -83,13 +86,17 @@ impl ScreenReaderState {
 		))
 		.await?;
 		//doing it this way for now. It could have been done with a From impl, but I don't want to make ssip_client_async a dependency of odilia_common, so this conversion is done directly inside state, especially since this enum isn't supposed to grow any further, in complexity or variants
-		let punctuation_mode=match config.speech.punctuation{
+		let punctuation_mode = match config.speech.punctuation {
 			PunctuationSpellingMode::Some => PunctuationMode::Some,
 			PunctuationSpellingMode::Most => PunctuationMode::Most,
 			PunctuationSpellingMode::None => PunctuationMode::None,
 			PunctuationSpellingMode::All => PunctuationMode::All,
 		};
-		ssip.send(SSIPRequest::SetPunctuationMode(ssip_client_async::ClientScope::Current, punctuation_mode)).await?;
+		ssip.send(SSIPRequest::SetPunctuationMode(
+			ssip_client_async::ClientScope::Current,
+			punctuation_mode,
+		))
+		.await?;
 		ssip.send(SSIPRequest::SetRate(
 			ssip_client_async::ClientScope::Current,
 			config.speech.rate,


### PR DESCRIPTION
this makes the configuration system far more resiliant to problems, as well as introduces some composability to it. This is how configuration is sourced at the moment, feedback welcome:

* default: the configuration struct has a default value, which is computed with a specific implementation of the default trait
* env vars: environment variables for the options available in the configuration, prefixed with ODILIA_
* configuration file sent via a cli argument: if that argument is present, it will be converted to a path and then merged in with the rest
* XDG_CONFIG_HOME: the file at $XDG_CONFIG_HOME/odilia/config.toml will be used
* system wide: configuration from /etc/odilia/config.toml will be used

if any of those files don't exist, nothing will happen, because a good known default set is provided at startup, anything else is in addition to that.
if a file in XDG_CONFIG_HOME doesn't exist, it will be created with the default configuration. I may move it to later in the chain, to populate it with values from all other config sources listed above instead of only the defaults