### PR TITLE
Use app names in notiication speech

### DIFF
--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -40,7 +40,7 @@ async fn notifications_monitor(
 		tokio::select! {
 		    Some(notification) = stream.next() => {
 		      let notification_message =
-			format!("new notification: {}, {}.", notification.title, notification.body);
+			format!("new notification: {}, {}, {}.", notification.app_name, notification.title, notification.body);
 		      state.say(Priority::Important, notification_message).await;
 		    },
 		    () = shutdown.cancelled() => {


### PR DESCRIPTION
We should not drop app names because some apps don't do it. Generally, it should work. Apps that do not comply with the standard would not have their name shown on notification daemons either, so we're still getting the same information.