### PR TITLE
Reinstate evdev-based key handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "cocoa"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667fdc068627a2816b9ff831201dd9864249d6ee8d190b9532357f1fc0f61ea7"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation 0.9.4",
+ "core-graphics 0.21.0",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,10 +707,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys 0.8.7",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.7.0",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a67c4378cf203eace8fb6567847eb641fd6ff933c1145a115c6ee820ebb978"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "foreign-types",
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -911,6 +976,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "epoll"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74351c3392ea1ff6cd2628e0042d268ac2371cb613252ff383b6dfa50d22fa79"
+dependencies = [
+ "bitflags 2.8.0",
+ "libc",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +999,29 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "evdev-rs"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b92abc30d5fd1e4f6440dee4d626abc68f4a9b5014dc1de575901e23c2e02321"
+dependencies = [
+ "bitflags 1.3.2",
+ "evdev-sys",
+ "libc",
+ "log",
+]
+
+[[package]]
+name = "evdev-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14ead42b547b15d47089c1243d907bcf0eb94e457046d3b315a26ac9c9e9ea6d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1013,6 +1111,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "futures"
@@ -1403,6 +1516,37 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "inotify"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46dd0a94b393c730779ccfd2a872b67b1eb67be3fc33082e733bdb38b5fde4d4"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "input-server"
+version = "0.1.0"
+dependencies = [
+ "nix 0.26.4",
+ "odilia-common",
+ "rdev",
+ "serde_json",
+ "tracing",
+]
 
 [[package]]
 name = "instant"
@@ -2005,6 +2149,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2201,6 +2351,24 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rdev"
+version = "0.5.3"
+source = "git+https://github.com/TTWNO/rdev/?branch=odilia-keys-v2#9462aa592a3f477b64f9ac8de6485ca7d3348ded"
+dependencies = [
+ "cocoa",
+ "core-foundation 0.7.0",
+ "core-foundation-sys 0.7.0",
+ "core-graphics 0.19.2",
+ "epoll",
+ "evdev-rs",
+ "inotify",
+ "lazy_static",
+ "libc",
+ "winapi",
+ "x11",
 ]
 
 [[package]]
@@ -2528,7 +2696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c18a6156d1f27a9592ee18c1a846ca8dd5c258b7179fc193ae87c74ebb666f5"
 dependencies = [
  "cfg-if",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
  "ntapi",
  "once_cell",
@@ -3403,6 +3571,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "x11"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,27 +73,28 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "async-broadcast"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener 5.4.0",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -130,8 +131,8 @@ checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.2.0",
- "futures-lite 2.5.0",
+ "fastrand 2.3.0",
+ "futures-lite 2.6.0",
  "slab",
 ]
 
@@ -143,7 +144,7 @@ checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
 dependencies = [
  "async-lock",
  "blocking",
- "futures-lite 2.5.0",
+ "futures-lite 2.6.0",
 ]
 
 [[package]]
@@ -157,7 +158,7 @@ dependencies = [
  "async-io",
  "async-lock",
  "blocking",
- "futures-lite 2.5.0",
+ "futures-lite 2.6.0",
  "once_cell",
 ]
 
@@ -171,7 +172,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.5.0",
+ "futures-lite 2.6.0",
  "parking",
  "polling",
  "rustix",
@@ -186,7 +187,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener 5.4.0",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -204,8 +205,8 @@ dependencies = [
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.3.1",
- "futures-lite 2.5.0",
+ "event-listener 5.4.0",
+ "futures-lite 2.6.0",
  "rustix",
  "tracing",
 ]
@@ -253,7 +254,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-lite 2.5.0",
+ "futures-lite 2.6.0",
  "gloo-timers",
  "kv-log-macro",
  "log",
@@ -295,9 +296,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -322,7 +323,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "atspi"
 version = "0.25.0"
-source = "git+https://github.com/odilia-app/atspi/?branch=zbus-5.0#2ddb9e1e6da959155c58615991a23c556ef6b2e6"
+source = "git+https://github.com/odilia-app/atspi/?branch=zbus-5.0#a4b50cf1a35ba252e0c046d8f1d241c843f30373"
 dependencies = [
  "atspi-common",
  "atspi-connection",
@@ -332,37 +333,37 @@ dependencies = [
 [[package]]
 name = "atspi-common"
 version = "0.9.0"
-source = "git+https://github.com/odilia-app/atspi/?branch=zbus-5.0#2ddb9e1e6da959155c58615991a23c556ef6b2e6"
+source = "git+https://github.com/odilia-app/atspi/?branch=zbus-5.0#a4b50cf1a35ba252e0c046d8f1d241c843f30373"
 dependencies = [
  "enumflags2",
  "serde",
  "static_assertions",
- "zbus 5.1.1",
+ "zbus",
  "zbus-lockstep",
  "zbus-lockstep-macros",
- "zbus_names 4.1.0",
- "zvariant 5.1.0",
+ "zbus_names",
+ "zvariant",
 ]
 
 [[package]]
 name = "atspi-connection"
 version = "0.9.0"
-source = "git+https://github.com/odilia-app/atspi/?branch=zbus-5.0#2ddb9e1e6da959155c58615991a23c556ef6b2e6"
+source = "git+https://github.com/odilia-app/atspi/?branch=zbus-5.0#a4b50cf1a35ba252e0c046d8f1d241c843f30373"
 dependencies = [
  "atspi-common",
  "atspi-proxies",
- "futures-lite 2.5.0",
- "zbus 5.1.1",
+ "futures-lite 2.6.0",
+ "zbus",
 ]
 
 [[package]]
 name = "atspi-proxies"
 version = "0.9.0"
-source = "git+https://github.com/odilia-app/atspi/?branch=zbus-5.0#2ddb9e1e6da959155c58615991a23c556ef6b2e6"
+source = "git+https://github.com/odilia-app/atspi/?branch=zbus-5.0#a4b50cf1a35ba252e0c046d8f1d241c843f30373"
 dependencies = [
  "atspi-common",
  "serde",
- "zbus 5.1.1",
+ "zbus",
 ]
 
 [[package]]
@@ -456,24 +457,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "blocking"
@@ -484,7 +476,7 @@ dependencies = [
  "async-channel 2.3.1",
  "async-task",
  "futures-io",
- "futures-lite 2.5.0",
+ "futures-lite 2.6.0",
  "piper",
 ]
 
@@ -496,9 +488,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -520,9 +512,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.2"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]
@@ -589,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -599,21 +591,21 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.3",
+ "clap_lex 0.7.4",
  "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -632,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
@@ -706,15 +698,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,18 +746,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -791,25 +774,15 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "dashmap"
@@ -850,16 +823,6 @@ name = "diatomic-waker"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
 
 [[package]]
 name = "dirs"
@@ -928,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "enumflags2"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d"
+checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
 dependencies = [
  "enumflags2_derive",
  "serde",
@@ -938,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
+checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -971,9 +934,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -986,7 +949,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener 5.4.0",
  "pin-project-lite",
 ]
 
@@ -1011,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "figment"
@@ -1143,11 +1106,11 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
- "fastrand 2.2.0",
+ "fastrand 2.3.0",
  "futures-core",
  "futures-io",
  "parking",
@@ -1218,16 +1181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,7 +1221,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1385,9 +1338,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1437,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1492,9 +1445,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.74"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1517,9 +1470,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libredox"
@@ -1527,15 +1480,15 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "libc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lock_api"
@@ -1549,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 dependencies = [
  "value-bag",
 ]
@@ -1644,9 +1597,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -1681,7 +1634,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1700,15 +1653,15 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.11.3"
+version = "4.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5134a72dc570b178bff81b01e81ab14a6fcc015391ed4b3b14853090658cd3a3"
+checksum = "96ae13fb6065b0865d2310dfa55ce319245052ed95fbbe2bc87c99962c58d73f"
 dependencies = [
  "log",
  "mac-notification-sys",
  "serde",
  "tauri-winrt-notification",
- "zbus 4.4.0",
+ "zbus",
 ]
 
 [[package]]
@@ -1776,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -1792,14 +1745,14 @@ dependencies = [
  "atspi-connection",
  "atspi-proxies",
  "circular-queue",
- "clap 4.5.21",
+ "clap 4.5.27",
  "console-subscriber",
  "derived-deref",
  "eyre",
  "figment",
  "futures",
  "futures-concurrency",
- "futures-lite 2.5.0",
+ "futures-lite 2.6.0",
  "lazy_static",
  "odilia-cache",
  "odilia-common",
@@ -1825,7 +1778,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-tree",
  "xdg",
- "zbus 5.1.1",
+ "zbus",
 ]
 
 [[package]]
@@ -1848,7 +1801,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
- "zbus 5.1.1",
+ "zbus",
 ]
 
 [[package]]
@@ -1870,7 +1823,7 @@ dependencies = [
  "tokio",
  "tracing",
  "xdg",
- "zbus 5.1.1",
+ "zbus",
 ]
 
 [[package]]
@@ -1901,7 +1854,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "zbus 5.1.1",
+ "zbus",
 ]
 
 [[package]]
@@ -2010,18 +1963,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2030,9 +1983,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -2047,7 +2000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
- "fastrand 2.2.0",
+ "fastrand 2.3.0",
  "futures-io",
 ]
 
@@ -2120,9 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -2193,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -2252,11 +2205,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -2328,22 +2281,22 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -2374,18 +2327,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2394,9 +2347,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -2431,17 +2384,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -2512,7 +2454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638da247dfdcacd5d8a96f7f7857c1b63d77f4771e5424ee3e34d056c8e5712"
 dependencies = [
  "strum_macros",
- "thiserror 2.0.3",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2564,9 +2506,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2606,12 +2548,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
- "fastrand 2.2.0",
+ "fastrand 2.3.0",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -2634,11 +2577,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -2654,9 +2597,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2675,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2704,9 +2647,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2732,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2743,9 +2686,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2767,9 +2710,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2807,7 +2750,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2987,12 +2930,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
 name = "uds_windows"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3026,9 +2963,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
@@ -3075,24 +3012,24 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -3101,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.47"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3114,9 +3051,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3124,9 +3061,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3137,15 +3074,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.74"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3286,7 +3226,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
@@ -3294,12 +3234,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-version"
-version = "0.1.1"
+name = "windows-targets"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6998aa457c9ba8ff2fb9f13e9d2a930dabcea28f1d0ab94d687d8b3654844515"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c12476c23a74725c539b24eae8bfc0dac4029c39cdb561d9f23616accd4ae26d"
+dependencies = [
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -3315,6 +3271,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,6 +3287,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3339,10 +3307,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3357,6 +3337,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3367,6 +3353,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3381,6 +3373,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,10 +3391,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.6.20"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]
@@ -3425,9 +3429,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zbus"
-version = "4.4.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+checksum = "192a0d989036cd60a1e91a54c9851fb9ad5bd96125d41803eed79d2e2ef74bd7"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -3440,45 +3444,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener 5.3.1",
- "futures-core",
- "futures-sink",
- "futures-util",
- "hex",
- "nix 0.29.0",
- "ordered-stream",
- "rand",
- "serde",
- "serde_repr",
- "sha1",
- "static_assertions",
- "tracing",
- "uds_windows",
- "windows-sys 0.52.0",
- "xdg-home",
- "zbus_macros 4.4.0",
- "zbus_names 3.0.0",
- "zvariant 4.2.0",
-]
-
-[[package]]
-name = "zbus"
-version = "5.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1162094dc63b1629fcc44150bcceeaa80798cd28bcbe7fa987b65a034c258608"
-dependencies = [
- "async-broadcast",
- "async-executor",
- "async-fs",
- "async-io",
- "async-lock",
- "async-process",
- "async-recursion",
- "async-task",
- "async-trait",
- "blocking",
- "enumflags2",
- "event-listener 5.3.1",
+ "event-listener 5.4.0",
  "futures-core",
  "futures-util",
  "hex",
@@ -3493,95 +3459,73 @@ dependencies = [
  "windows-sys 0.59.0",
  "winnow",
  "xdg-home",
- "zbus_macros 5.1.1",
- "zbus_names 4.1.0",
- "zvariant 5.1.0",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
 ]
 
 [[package]]
 name = "zbus-lockstep"
-version = "0.4.4"
-source = "git+https://github.com/luukvanderduim/zbus-lockstep?branch=0.5.0-rc1#11618331fd9b5d6b12f10e13aa706050e1f001f2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22426b1bc2aca91de97772506f0655fa373448e6010d79d5d5880915c388409"
 dependencies = [
  "zbus_xml",
- "zvariant 5.1.0",
+ "zvariant",
 ]
 
 [[package]]
 name = "zbus-lockstep-macros"
-version = "0.4.4"
-source = "git+https://github.com/luukvanderduim/zbus-lockstep?branch=0.5.0-rc1#11618331fd9b5d6b12f10e13aa706050e1f001f2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "100ffec29ed51859052f4563061abe35557acb56ba574510571f8398efc70a29"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
  "zbus-lockstep",
  "zbus_xml",
- "zvariant 5.1.0",
+ "zvariant",
 ]
 
 [[package]]
 name = "zbus_macros"
-version = "4.4.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+checksum = "3685b5c81fce630efc3e143a4ded235b107f1b1cdf186c3f115529e5e5ae4265"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
- "zvariant_utils 2.1.0",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "5.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd2dcdce3e2727f7d74b7e33b5a89539b3cc31049562137faf7ae4eb86cd16d"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zbus_names 4.1.0",
- "zvariant 5.1.0",
- "zvariant_utils 3.0.2",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "3.0.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
-dependencies = [
- "serde",
- "static_assertions",
- "zvariant 4.2.0",
-]
-
-[[package]]
-name = "zbus_names"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856b7a38811f71846fd47856ceee8bccaec8399ff53fb370247e66081ace647b"
+checksum = "519629a3f80976d89c575895b05677cbc45eaf9f70d62a364d819ba646409cc8"
 dependencies = [
  "serde",
  "static_assertions",
  "winnow",
- "zvariant 5.1.0",
+ "zvariant",
 ]
 
 [[package]]
 name = "zbus_xml"
-version = "5.0.1"
+version = "5.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c210addbcb424e91411ef782a5a1e264b5a5d268766faccd7d113c7c0440b9ab"
+checksum = "589e9a02bfafb9754bb2340a9e3b38f389772684c63d9637e76b1870377bec29"
 dependencies = [
  "quick-xml 0.36.2",
  "serde",
  "static_assertions",
- "zbus_names 4.1.0",
- "zvariant 5.1.0",
+ "zbus_names",
+ "zvariant",
 ]
 
 [[package]]
@@ -3607,74 +3551,37 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "4.2.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "static_assertions",
- "zvariant_derive 4.2.0",
-]
-
-[[package]]
-name = "zvariant"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1200ee6ac32f1e5a312e455a949a4794855515d34f9909f4a3e082d14e1a56f"
+checksum = "55e6b9b5f1361de2d5e7d9fd1ee5f6f7fcb6060618a1f82f3472f58f2b8d4be9"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "static_assertions",
  "winnow",
- "zvariant_derive 5.1.0",
- "zvariant_utils 3.0.2",
+ "zvariant_derive",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "4.2.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+checksum = "573a8dd76961957108b10f7a45bac6ab1ea3e9b7fe01aff88325dc57bb8f5c8b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
- "zvariant_utils 2.1.0",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687e3b97fae6c9104fbbd36c73d27d149abf04fb874e2efbd84838763daa8916"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zvariant_utils 3.0.2",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "2.1.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d1d011a38f12360e5fcccceeff5e2c42a8eb7f27f0dcba97a0862ede05c9c6"
+checksum = "ddd46446ea2a1f353bfda53e35f17633afa79f4fe290a611c94645c69fe96a50"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ odilia-common = { version = "0.3.0", path = "./common", features = ["tokio"] }
 odilia-cache = { version = "0.3.0", path = "./cache" }
 eyre = "0.6.8"
 nix = "0.26.2"
-serde_json = "1.0.89"
+serde_json = "1.0"
 serde = { version = "1.0.194", features = ["derive"] }
 ssip-client-async = { default-features = false, features = ["tokio"], version = "0.14.0" }
 tokio = { version = "^1.22.0", default-features = false, features = ["sync", "macros", "rt", "signal", "tracing"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["odilia", "odilia-notify"]
 members = [
   "cache",
   "common",
-  "input",
+  "input", "input-server",
   "odilia",
   "odilia-notify",
 ]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -22,7 +22,7 @@ atspi-common.workspace = true
 atspi-proxies.workspace = true
 bitflags = "1.3.2"
 serde = "1.0.147"
-smartstring = "1.0.1"
+smartstring = { version = "1.0.1", features = ["serde"] }
 thiserror = "1.0.37"
 zbus.workspace = true
 serde_plain.workspace = true

--- a/common/src/command.rs
+++ b/common/src/command.rs
@@ -140,15 +140,17 @@ pub struct Speak(pub String, pub Priority);
 #[derive(Debug, Clone)]
 pub struct Focus(pub AccessiblePrimitive);
 
-impl CommandType for Speak {
-	const CTYPE: OdiliaCommandDiscriminants = OdiliaCommandDiscriminants::Speak;
+macro_rules! impl_command_type {
+	($type:ty, $disc:ident) => {
+		impl CommandType for $type {
+			const CTYPE: OdiliaCommandDiscriminants = OdiliaCommandDiscriminants::$disc;
+		}
+	};
 }
-impl CommandType for Focus {
-	const CTYPE: OdiliaCommandDiscriminants = OdiliaCommandDiscriminants::Focus;
-}
-impl CommandType for CaretPos {
-	const CTYPE: OdiliaCommandDiscriminants = OdiliaCommandDiscriminants::CaretPos;
-}
+
+impl_command_type!(Focus, Focus);
+impl_command_type!(Speak, Speak);
+impl_command_type!(CaretPos, CaretPos);
 
 #[derive(Debug, Clone, EnumDiscriminants)]
 #[strum_discriminants(derive(Ord, PartialOrd, Display))]

--- a/common/src/events.rs
+++ b/common/src/events.rs
@@ -1,9 +1,11 @@
+use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
+use strum::{Display, EnumDiscriminants};
 
 use crate::modes::ScreenReaderMode;
 use atspi_common::Role;
 
-#[derive(Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Clone, Hash, Serialize, Deserialize, Debug)]
 /// A list of features supported natively by Odilia.
 pub enum Feature {
 	/// Unimplemented, but will eventually stop all speech until re-activated.
@@ -12,27 +14,68 @@ pub enum Feature {
 	Braille, // TODO
 }
 
-#[derive(Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Clone, Hash, Serialize, Deserialize, Debug)]
 #[serde(tag = "direction")]
 pub enum Direction {
 	Forward,
 	Backward,
 }
 
-#[derive(Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
-#[serde(tag = "event", content = "args", rename_all = "camelCase")]
+pub trait EventType {
+	const ETYPE: ScreenReaderEventDiscriminants;
+}
+#[enum_dispatch]
+pub trait EventTypeDynamic {
+	fn etype(&self) -> ScreenReaderEventDiscriminants;
+}
+impl<T: EventType> EventTypeDynamic for T {
+	fn etype(&self) -> ScreenReaderEventDiscriminants {
+		T::ETYPE
+	}
+}
+macro_rules! impl_event_type {
+	($type:ty, $disc:ident) => {
+		impl EventType for $type {
+			const ETYPE: ScreenReaderEventDiscriminants =
+				ScreenReaderEventDiscriminants::$disc;
+		}
+	};
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StopSpeech;
+impl_event_type!(StopSpeech, StopSpeech);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Enable(pub Feature);
+impl_event_type!(Enable, Enable);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Disable(pub Feature);
+impl_event_type!(Disable, Disable);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChangeMode(pub ScreenReaderMode);
+impl_event_type!(ChangeMode, ChangeMode);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StructuralNavigation(pub Direction, pub Role);
+impl_event_type!(StructuralNavigation, StructuralNavigation);
+
+#[derive(Eq, PartialEq, Clone, Serialize, Deserialize, Debug, EnumDiscriminants)]
 /// Events which can be trigged through Odilia's external API.
 /// Subject to change without notice until v1.0, but we're [open to suggestions on our Github](https://github.com/odilia-app/odilia/); please reach out with features you'd like to see.
+#[strum_discriminants(derive(Ord, PartialOrd, Display))]
+#[enum_dispatch(EventTypeDynamic)]
 pub enum ScreenReaderEvent {
-	/// when we need to do "something" but this is always hardcoded as nothing
-	Noop,
 	/// Stop all current speech.
-	StopSpeech,
-	/// Enable a feature from working.
-	Enable(Feature),
+	StopSpeech(StopSpeech),
+	/// Enable a feature.
+	Enable(Enable),
 	/// Disable a feature.
-	Disable(Feature),
+	Disable(Disable),
 	/// Change mode of the screen reader. This is currently global, but it should be per application, and an update should only affect the current application.
-	ChangeMode(ScreenReaderMode),
-	StructuralNavigation(Direction, Role),
+	ChangeMode(ChangeMode),
+	/// Navigate to the next [`Role`] in [`Direction`] by depth-first search.
+	StructuralNavigation(StructuralNavigation),
 }

--- a/common/src/modes.rs
+++ b/common/src/modes.rs
@@ -1,13 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Debug, Eq, Hash, Serialize, Deserialize)]
-pub struct ScreenReaderMode {
-	pub name: String,
-}
-
-impl ScreenReaderMode {
-	#[must_use]
-	pub fn new(name: &str) -> Self {
-		ScreenReaderMode { name: name.to_string() }
-	}
+pub enum ScreenReaderMode {
+	Focus,
+	Browse,
 }

--- a/input-server/Cargo.toml
+++ b/input-server/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "input-server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+nix.workspace = true
+odilia-common.workspace = true
+rdev = { git = "https://github.com/TTWNO/rdev/", branch = "odilia-keys-v2", features = ["unstable_grab"] }
+serde_json.workspace = true
+tracing.workspace = true

--- a/input-server/src/main.rs
+++ b/input-server/src/main.rs
@@ -1,0 +1,172 @@
+use rdev::{grab, Event, EventType, Key};
+use nix::unistd::Uid;
+use odilia_common::{
+    events::ScreenReaderEvent as OdiliaEvent,
+    events::{
+        StopSpeech,
+        StructuralNavigation,
+        ChangeMode,
+        Enable,
+        Disable,
+    },
+    modes::ScreenReaderMode as Mode,
+};
+
+use std::env;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::mpsc::{sync_channel, SyncSender, Receiver};
+use std::os::unix::net::UnixStream;
+use std::thread;
+
+fn get_file_paths() -> (PathBuf, PathBuf) {
+  match env::var("XDG_RUNTIME_DIR") {
+    Ok(val) => {
+      tracing::info!(
+                "XDG_RUNTIME_DIR Variable is present, using it's value as default file path."
+            );
+
+      let pid_file_path = format!("{val}/odilias.pid");
+      let sock_file_path = format!("{val}/odilia.sock");
+
+      (pid_file_path.into(), sock_file_path.into())
+    }
+    Err(e) => {
+      tracing::warn!(error=%e, "XDG_RUNTIME_DIR Variable is not set, falling back to hardcoded path");
+
+      let pid_file_path = format!("/run/user/{}/odilias.pid", Uid::current());
+      let sock_file_path = format!("/run/user/{}/odilia.sock", Uid::current());
+
+      (pid_file_path.into(), sock_file_path.into())
+    }
+  }
+}
+
+#[derive(Default)]
+pub struct ComboSet {
+	combos: Vec<(Vec<Key>, OdiliaEvent)>,
+}
+
+pub struct State {
+	activation_key_pressed: bool,
+	pressed: Vec<Key>,
+	combos: ComboSet,
+  tx: SyncSender<OdiliaEvent>,
+}
+
+fn handle_events_to_socket(rx: Receiver<OdiliaEvent>) {
+    let (_pid_path, sock_path) = get_file_paths();
+    println!("SOCK PATH: {sock_path:?}");
+    let Ok(mut stream) = UnixStream::connect(&sock_path) else {
+        panic!("Unable to connect to stream {:?}", sock_path);
+    };
+    for event in rx.iter() {
+        let val = serde_json::to_string(&event)
+            .expect("Should be able to serialize any event!");
+        stream.write_all(val.as_bytes())
+            .expect("Able to write to stream!");
+    }
+}
+
+fn main() {
+    // syncronous, bounded channel
+    // NOTE: this will _block the input thread_ if events are not removed from it often.
+    // This _should_ never be a problem, because two threads are running, but you never know.
+    let (tx, rx) = sync_channel::<OdiliaEvent>(255);
+		let combos = vec![
+			(vec![Key::KeyA], ChangeMode(Mode::Browse).into()),
+			(vec![Key::KeyF], ChangeMode(Mode::Focus).into()),
+      // use Odilia + G to mean "stop speech"; like Emacs
+      // this allows us to vastly simplify the key handling code since we don't have to create a
+      // virtual keyboard and send control if the user is _actually_ using control vs. using it to
+      // stop speech.
+			(vec![Key::KeyG], StopSpeech.into()),
+		];
+    let state = State {
+      activation_key_pressed: false,
+      pressed: Vec::new(),
+      combos: ComboSet{ combos },
+      tx,
+    };
+    let _ = thread::spawn(move || {
+        // This will block.
+        if let Err(error) = grab(callback, state) {
+            println!("Error: {:?}", error)
+        }
+    });
+    handle_events_to_socket(rx);
+}
+
+fn callback(event: Event, state: &mut State) -> Option<Event> {
+		println!("My callback {:?}", event);
+		match (event.event_type, state.activation_key_pressed) {
+        // if capslock is pressed while activation is disabled
+				(EventType::KeyPress(Key::CapsLock), false) => {
+            // enable it
+						state.activation_key_pressed = true;
+						println!("Cancelling CL!");
+            // swallow the event
+						None
+				},
+        // if capslock is released while activation is disabled (should never happen)
+				(EventType::KeyRelease(Key::CapsLock), false) => {
+            // swallow the event
+						None
+				},
+        // if capslock is pressed while activation is enabled (usually the result of holding down
+        // the key)
+				(EventType::KeyPress(Key::CapsLock), true) => {
+            // swallow the event
+						None
+				},
+        // if capslock is released while activate is enabled
+				(EventType::KeyRelease(Key::CapsLock), true) => {
+            // disable activate state
+						state.activation_key_pressed = false;
+						println!("Cancelling CL! Dropping activation feature.");
+            // and swallow event
+						None
+				},
+        // if a key press is made while activation is enabled
+				(EventType::KeyPress(other), true) => {
+            // if the key is already pressed (i.e., it's been held down)
+						let None = state.pressed.iter().position(|key| *key == other) else {
+                // swallow the event immediately, do not pass go
+								return None;
+						};
+            // otherwise, add it to the list of held keys
+						state.pressed.push(other);
+            // look in the combos
+						for combo in &state.combos.combos {
+							println!("Combo: {combo:?}");
+							println!("Pressed {:?}", state.pressed);
+              // if a combo matches the held keys (must be in right order)
+							if combo.0 == state.pressed {
+                  // print out the command
+								println!("Combo found for {:?}", combo.1);
+                state.tx.send(combo.1.clone())
+                    .expect("To be able to send the combo over the channel");
+							}
+						}
+            // swallow the event
+						None
+				},
+        // if a key release is made while activation mode is on
+				(EventType::KeyRelease(other), true) => {
+            // if it's previously been pressed
+						if let Some(idx) = state.pressed.iter().position(|key| *key == other) {
+              // remove it from the list of held keys
+							state.pressed.remove(idx);
+              // and swallow the event
+							None
+            // otherwise, it was a key held from before the activation was enabled
+						} else {
+              // pass this through to the other layers, as applications need to be notified about
+              // letting go of the key
+							Some(event)
+						}
+				},
+        // all other cases (having to do with the mouse): pass through
+				_ => Some(event),
+		}
+}

--- a/input/src/lib.rs
+++ b/input/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
 	time::{SystemTime, UNIX_EPOCH},
 };
 use sysinfo::{ProcessExt, System, SystemExt};
-use tokio::{fs, io::AsyncReadExt, net::UnixListener, sync::mpsc::Sender};
+use tokio::{fs, net::unix::SocketAddr, net::UnixListener, net::UnixStream, sync::mpsc::Sender};
 use tokio_util::sync::CancellationToken;
 
 #[tracing::instrument(ret)]
@@ -133,41 +133,72 @@ pub async fn sr_event_receiver(
 	tracing::debug!("Listener activated!");
 	loop {
 		tokio::select! {
-			msg = listener.accept() => {
-			    match msg {
-				Ok((mut socket, address)) => {
-				    tracing::debug!("Ok from socket");
-				    let mut response = String::new();
-				    match socket.read_to_string(&mut response).await {
-				      Ok(_) => {},
-				      Err(e) => {
-					tracing::error!("Error reading from socket {:#?}", e);
-				      }
-				    }
-				    // if valid screen reader event
-				    match serde_json::from_str::<ScreenReaderEvent>(&response) {
-				      Ok(sre) => {
-					if let Err(e) = event_sender.send(sre).await {
-					  tracing::error!("Error sending ScreenReaderEvent over socket: {}", e);
-		} else {
-					  tracing::debug!("Sent SR event");
-		}
-				      },
-				      Err(e) => tracing::debug!("Invalid odilia event. {:#?}", e),
-				    }
-				    tracing::debug!("Socket: {:?} Address: {:?} Response: {}", socket, address, response);
-				},
-				Err(e) => tracing::error!("accept function failed: {:?}", e),
+			    msg = listener.accept() => {
+				match msg {
+				    Ok((socket, address)) => {
+					tracing::debug!("Ok from socket");
+		tokio::spawn(handle_event(socket, address, event_sender.clone(), shutdown.clone()));
+				    },
+				    Err(e) => tracing::error!("accept function failed: {:?}", e),
+				}
+				continue;
 			    }
-			    continue;
+			    () = shutdown.cancelled() => {
+				tracing::debug!("Shutting down input socket due to cancellation token");
+				break;
+			    }
 			}
-			() = shutdown.cancelled() => {
-			    tracing::debug!("Shutting down input socket due to cancellation token");
-			    break;
-			}
-		    }
 	}
 	Ok(())
+}
+
+async fn handle_event(
+	socket: UnixStream,
+	address: SocketAddr,
+	event_sender: Sender<ScreenReaderEvent>,
+	shutdown: CancellationToken,
+) {
+	loop {
+		tokio::select! {
+			Ok(()) = socket.readable() => {
+			let mut buf = [0; 4096];
+						let bytes = match socket.try_read(&mut buf) {
+						  Ok(0) => {
+			      tracing::debug!("Socket {socket:?} was disconnected!");
+			      break;
+			  },
+			  Ok(b) => b,
+			  Err(ref e) if e.kind() == tokio::io::ErrorKind::WouldBlock => {
+			      continue;
+			  },
+						  Err(e) => {
+						    tracing::error!("Error reading from socket {:#?}", e);
+			    continue;
+						  }
+						};
+			let response = std::str::from_utf8(&buf[..bytes])
+			    .expect("Valid UTF-8");
+						// if valid screen reader event
+			println!("RESP: '{response}'");
+						match serde_json::from_str::<ScreenReaderEvent>(response) {
+						  Ok(sre) => {
+						    if let Err(e) = event_sender.send(sre).await {
+						      tracing::error!("Error sending ScreenReaderEvent over socket: {}", e);
+			    } else {
+						      tracing::debug!("Sent SR event");
+			    }
+						  },
+						  Err(e) => tracing::debug!("Invalid odilia event. {:#?}", e),
+						}
+						tracing::debug!("Socket: {:?} Address: {:?} Response: {}", socket, address, response);
+
+		    }
+				    () = shutdown.cancelled() => {
+					tracing::debug!("Shutting down listening on input socket {socket:?} due to cancellation token!");
+					break;
+				    }
+		}
+	}
 }
 
 #[tracing::instrument(ret)]

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -21,6 +21,7 @@ use crate::cli::Args;
 use crate::state::AccessibleHistory;
 use crate::state::Command;
 use crate::state::CurrentCaretPos;
+use crate::state::InputEvent;
 use crate::state::LastCaretPos;
 use crate::state::LastFocused;
 use crate::state::ScreenReaderState;
@@ -38,6 +39,7 @@ use futures::{future::FutureExt, StreamExt};
 use odilia_common::{
 	command::{CaretPos, Focus, IntoCommands, OdiliaCommand, Speak, TryIntoCommands},
 	errors::OdiliaError,
+	events::{ScreenReaderEvent, StopSpeech},
 	settings::ApplicationConfig,
 };
 
@@ -190,6 +192,11 @@ async fn new_caret_pos(
 	Ok(())
 }
 
+#[tracing::instrument(ret)]
+async fn stop_speech(InputEvent(_): InputEvent<StopSpeech>) -> impl TryIntoCommands {
+	(Priority::Text, "Stop talking, eh!")
+}
+
 #[tracing::instrument(ret, err)]
 async fn caret_moved(
 	caret_moved: CacheEvent<TextCaretMovedEvent>,
@@ -253,6 +260,7 @@ async fn main() -> eyre::Result<()> {
 	let (ssip_req_tx, ssip_req_rx) = mpsc::channel::<ssip_client_async::Request>(128);
 	let (mut ev_tx, ev_rx) =
 		futures::channel::mpsc::channel::<Result<atspi::Event, atspi::AtspiError>>(10_000);
+	let (input_tx, input_rx) = mpsc::channel::<ScreenReaderEvent>(255);
 	// Initialize state
 	let state = Arc::new(ScreenReaderState::new(ssip_req_tx, config).await?);
 	let ssip = odilia_tts::create_ssip_client().await?;
@@ -283,7 +291,8 @@ async fn main() -> eyre::Result<()> {
 		.atspi_listener(doc_loaded)
 		.atspi_listener(caret_moved)
 		.atspi_listener(focused)
-		.atspi_listener(unfocused);
+		.atspi_listener(unfocused)
+		.input_listener(stop_speech);
 
 	let ssip_event_receiver =
 		odilia_tts::handle_ssip_commands(ssip, ssip_req_rx, token.clone())
@@ -306,12 +315,16 @@ async fn main() -> eyre::Result<()> {
 			}
 		}
 	};
-	let atspi_handlers_task = handlers.atspi_handler(ev_rx);
+	let atspi_handlers_task = handlers.clone().atspi_handler(ev_rx);
+	let input_task = odilia_input::sr_event_receiver(input_tx, token.clone());
+	let input_handler = handlers.input_handler(input_rx);
 
 	tracker.spawn(ssip_event_receiver);
 	tracker.spawn(notification_task);
 	tracker.spawn(atspi_handlers_task);
 	tracker.spawn(event_send_task);
+	tracker.spawn(input_task);
+	tracker.spawn(input_handler);
 	tracker.close();
 	let _ = sigterm_signal_watcher(token, tracker)
 		.await

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -27,6 +27,7 @@ use odilia_common::{
 	cache::AccessiblePrimitive,
 	command::CommandType,
 	errors::{CacheError, OdiliaError},
+	events::EventType,
 	settings::{speech::PunctuationSpellingMode, ApplicationConfig},
 	types::TextSelectionArea,
 	Result as OdiliaResult,
@@ -72,6 +73,22 @@ pub struct Speech(pub Sender<SSIPRequest>);
 pub struct Command<T>(pub T)
 where
 	T: CommandType;
+
+#[derive(Debug)]
+pub struct InputEvent<T>(pub T)
+where
+	T: EventType;
+
+impl<E> TryFromState<Arc<ScreenReaderState>, E> for InputEvent<E>
+where
+	E: EventType + Clone + Debug,
+{
+	type Error = OdiliaError;
+	type Future = Ready<Result<InputEvent<E>, Self::Error>>;
+	fn try_from_state(_state: Arc<ScreenReaderState>, i_ev: E) -> Self::Future {
+		ok(InputEvent(i_ev))
+	}
+}
 
 impl<C> TryFromState<Arc<ScreenReaderState>, C> for Command<C>
 where

--- a/odilia/src/tower/choice.rs
+++ b/odilia/src/tower/choice.rs
@@ -8,6 +8,7 @@ use odilia_common::{
 		OdiliaCommandDiscriminants as CommandDiscriminants,
 	},
 	errors::OdiliaError,
+	events::{EventType, EventTypeDynamic, ScreenReaderEvent, ScreenReaderEventDiscriminants},
 };
 use std::collections::{btree_map::Entry, BTreeMap};
 use std::fmt::Debug;
@@ -107,6 +108,14 @@ where
 		C::CTYPE
 	}
 }
+impl<E> ChooserStatic<ScreenReaderEventDiscriminants> for E
+where
+	E: EventType,
+{
+	fn identifier() -> ScreenReaderEventDiscriminants {
+		E::ETYPE
+	}
+}
 
 impl Chooser<(&'static str, &'static str)> for Event {
 	fn identifier(&self) -> (&'static str, &'static str) {
@@ -116,5 +125,10 @@ impl Chooser<(&'static str, &'static str)> for Event {
 impl Chooser<CommandDiscriminants> for Command {
 	fn identifier(&self) -> CommandDiscriminants {
 		self.ctype()
+	}
+}
+impl Chooser<ScreenReaderEventDiscriminants> for ScreenReaderEvent {
+	fn identifier(&self) -> ScreenReaderEventDiscriminants {
+		self.etype()
 	}
 }

--- a/odilia/src/tower/handlers.rs
+++ b/odilia/src/tower/handlers.rs
@@ -12,7 +12,10 @@ use atspi::BusProperties;
 use atspi::Event;
 use atspi::EventProperties;
 use atspi::EventTypeProperties;
-use odilia_common::errors::OdiliaError;
+use odilia_common::{
+	errors::OdiliaError, events::EventType, events::ScreenReaderEvent,
+	events::ScreenReaderEventDiscriminants,
+};
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -35,16 +38,28 @@ type Error = OdiliaError;
 
 type AtspiHandler = BoxCloneService<Event, (), Error>;
 type CommandHandler = BoxCloneService<Command, (), Error>;
+type InputHandler = BoxCloneService<ScreenReaderEvent, (), Error>;
 
+#[derive(Clone)]
 pub struct Handlers {
 	state: Arc<ScreenReaderState>,
 	atspi: ChoiceService<(&'static str, &'static str), ServiceSet<AtspiHandler>, Event>,
 	command: ChoiceService<CommandDiscriminants, ServiceSet<CommandHandler>, Command>,
+	input: ChoiceService<
+		ScreenReaderEventDiscriminants,
+		ServiceSet<InputHandler>,
+		ScreenReaderEvent,
+	>,
 }
 
 impl Handlers {
 	pub fn new(state: Arc<ScreenReaderState>) -> Self {
-		Handlers { state, atspi: ChoiceService::new(), command: ChoiceService::new() }
+		Handlers {
+			state,
+			atspi: ChoiceService::new(),
+			command: ChoiceService::new(),
+			input: ChoiceService::new(),
+		}
 	}
 	pub async fn command_handler(mut self, mut commands: Receiver<Command>) {
 		loop {
@@ -80,6 +95,20 @@ impl Handlers {
 			}
 		}
 	}
+	#[tracing::instrument(skip_all)]
+	pub async fn input_handler(mut self, mut events: Receiver<ScreenReaderEvent>) {
+		std::pin::pin!(&mut events);
+		loop {
+			let maybe_ev = events.recv().await;
+			let Some(ev) = maybe_ev else {
+				tracing::error!("Error in processing {maybe_ev:?}");
+				continue;
+			};
+			if let Err(e) = self.input.call(ev).await {
+				tracing::error!("{e:?}");
+			}
+		}
+	}
 	pub fn command_listener<H, T, C, R>(mut self, handler: H) -> Self
 	where
 		H: Handler<T, Response = R> + Send + Clone + 'static,
@@ -101,7 +130,48 @@ impl Handlers {
 			.request_try_from()
 			.boxed_clone();
 		self.command.entry(C::identifier()).or_default().push(bs);
-		Self { state: self.state, atspi: self.atspi, command: self.command }
+		Self {
+			state: self.state,
+			atspi: self.atspi,
+			command: self.command,
+			input: self.input,
+		}
+	}
+	pub fn input_listener<H, T, R, E>(mut self, handler: H) -> Self
+	where
+		H: Handler<T, Response = R> + Send + Clone + 'static,
+		<H as Handler<T>>::Future: Send,
+		E: EventType + ChooserStatic<ScreenReaderEventDiscriminants> + Send + 'static,
+		ScreenReaderEvent: TryInto<E>,
+		OdiliaError: From<<ScreenReaderEvent as TryInto<E>>::Error>
+			+ From<<T as TryFromState<Arc<ScreenReaderState>, E>>::Error>,
+		R: TryIntoCommands + 'static,
+		T: TryFromState<Arc<ScreenReaderState>, E> + Send + 'static,
+		<T as TryFromState<Arc<ScreenReaderState>, E>>::Future: Send,
+		<T as TryFromState<Arc<ScreenReaderState>, E>>::Error: Send,
+	{
+		let bs = handler
+			.into_service()
+			.unwrap_map(TryIntoCommands::try_into_commands)
+			.request_async_try_from()
+			.with_state(Arc::clone(&self.state))
+			.request_try_from()
+			.iter_into(self.command.clone())
+			.map_result(
+				|res: Result<Vec<Vec<Result<(), OdiliaError>>>, OdiliaError>| {
+					res?.into_iter()
+						.flatten()
+						.collect::<Result<(), OdiliaError>>()
+				},
+			)
+			.boxed_clone();
+		self.input.entry(E::identifier()).or_default().push(bs);
+		Self {
+			state: self.state,
+			atspi: self.atspi,
+			command: self.command,
+			input: self.input,
+		}
 	}
 	pub fn atspi_listener<H, T, R, E>(mut self, handler: H) -> Self
 	where
@@ -139,6 +209,11 @@ impl Handlers {
 			)
 			.boxed_clone();
 		self.atspi.entry(E::identifier()).or_default().push(bs);
-		Self { state: self.state, atspi: self.atspi, command: self.command }
+		Self {
+			state: self.state,
+			atspi: self.atspi,
+			command: self.command,
+			input: self.input,
+		}
 	}
 }

--- a/odilia/src/tower/state_changed.rs
+++ b/odilia/src/tower/state_changed.rs
@@ -1,6 +1,6 @@
 use atspi_common::{
-  events::MessageConversion,
-	events::object::StateChangedEvent, AtspiError, EventProperties, State as AtspiState,
+	events::object::StateChangedEvent, events::MessageConversion, AtspiError, EventProperties,
+	State as AtspiState,
 };
 use derived_deref::{Deref, DerefMut};
 use refinement::Predicate;
@@ -34,13 +34,17 @@ where
 	const REGISTRY_EVENT_STRING: &'static str = StateChangedEvent::REGISTRY_EVENT_STRING;
 }
 impl<S, E> MessageConversion for StateChanged<S, E>
-    where StateChanged<S, E>: TryFrom<StateChangedEvent>, 
+where
+	StateChanged<S, E>: TryFrom<StateChangedEvent>,
 {
 	type Body = <StateChangedEvent as MessageConversion>::Body;
-  fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-      Self::from_message_unchecked_parts(msg.try_into()?, msg.body().deserialize()?)
-  }
-	fn from_message_unchecked_parts(or: atspi::ObjectRef, bdy: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Self::from_message_unchecked_parts(msg.try_into()?, msg.body().deserialize()?)
+	}
+	fn from_message_unchecked_parts(
+		or: atspi::ObjectRef,
+		bdy: Self::Body,
+	) -> Result<Self, AtspiError> {
 		let ev = StateChangedEvent::from_message_unchecked_parts(or, bdy)?;
 		// TODO: we do not have an appropriate event type here; this should really be an OdiliaError.
 		// We may want to consider adding a type Error in the BusProperties impl.


### PR DESCRIPTION
- **Use generic version of serde_json**
- **fmt**
- **Cleanup using macro**
- **Make mode an exaustive enum**
- **Update events struct to work like Command does**
- **Spawn new task for input events**
- **Update services to handle input events**
- **Use new input event handlers**
- **Update cargo lock**
- **Add input server binary**
- **Update cargo lock**
