### PR TITLE
Remove Bloat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,19 +236,13 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "atspi"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e595c4a1ad7be9c5514980ae8c6e4810f17e9d24bd7bbc5ad67e7aef4dc1c819"
 dependencies = [
  "atspi-common",
- "atspi-connection",
- "atspi-proxies",
 ]
 
 [[package]]
 name = "atspi-common"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2b4e5cb03df74eae47d7c47918e109db6ad3c825602f236d060a221f4d23b8"
 dependencies = [
  "enumflags2",
  "serde",
@@ -263,20 +257,15 @@ dependencies = [
 [[package]]
 name = "atspi-connection"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832ecc699b7b1e801e49f5dccb4db1472519537498448f944e8cdcfcdd92e6b3"
 dependencies = [
  "atspi-common",
  "atspi-proxies",
- "futures-lite",
  "zbus",
 ]
 
 [[package]]
 name = "atspi-proxies"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b9aef6811420186bed52af0af10fed051ef554b6206edbaffddcfa2dd90e43"
 dependencies = [
  "atspi-common",
  "serde",
@@ -1824,11 +1813,9 @@ version = "0.3.0"
 dependencies = [
  "async-channel",
  "atspi",
- "atspi-common",
- "atspi-proxies",
  "enum_dispatch",
- "futures",
  "futures-concurrency",
+ "futures-util",
  "indextree",
  "serde",
  "serde_plain",
@@ -1839,6 +1826,7 @@ dependencies = [
  "tracing",
  "xdg",
  "zbus",
+ "zbus_names",
  "zvariant",
 ]
 
@@ -1893,8 +1881,9 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "futures",
+ "futures-util",
  "odilia-common",
- "pin-project",
+ "pin-project-lite",
  "ssip",
  "static_assertions",
  "tower 0.5.2",
@@ -2547,7 +2536,6 @@ dependencies = [
  "serde",
  "strum_macros",
  "thiserror",
- "zvariant",
 ]
 
 [[package]]
@@ -2715,6 +2703,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "tracing",
@@ -2873,9 +2862,9 @@ dependencies = [
 name = "tower-iter"
 version = "0.1.0"
 dependencies = [
- "futures",
  "futures-lite",
- "pin-project",
+ "futures-util",
+ "pin-project-lite",
  "tower 0.5.2",
 ]
 
@@ -3436,6 +3425,7 @@ dependencies = [
  "ordered-stream",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "windows-sys 0.59.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,20 +981,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-buffered"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,7 +1000,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -1083,13 +1068,9 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1739,9 +1720,9 @@ dependencies = [
  "config",
  "console-subscriber",
  "derived-deref",
- "futures",
  "futures-concurrency",
  "futures-lite",
+ "futures-util",
  "lazy_static",
  "lexopt",
  "odilia-cache",
@@ -1781,9 +1762,9 @@ dependencies = [
  "criterion",
  "dashmap",
  "evmap",
- "futures",
  "futures-concurrency",
  "futures-lite",
+ "futures-util",
  "fxhash",
  "indextree",
  "itertools 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,7 +1768,6 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
- "toml",
  "tower 0.5.2",
  "tower-iter",
  "tracing",
@@ -1837,7 +1836,6 @@ version = "0.0.3"
 dependencies = [
  "async-channel",
  "async-fs",
- "async-io",
  "async-net",
  "futures",
  "futures-lite",
@@ -1846,7 +1844,6 @@ dependencies = [
  "serde_json",
  "smol-cancellation-token",
  "sysinfo",
- "tokio",
  "tracing",
 ]
 
@@ -1896,12 +1893,9 @@ name = "odilia-tts"
 version = "0.1.4"
 dependencies = [
  "async-channel",
- "async-fs",
- "async-io",
  "async-net",
  "futures",
  "futures-lite",
- "odilia-common",
  "smol-cancellation-token",
  "ssip-client-async",
  "tracing",
@@ -2819,15 +2813,8 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
  "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tonic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,6 +1423,7 @@ dependencies = [
  "async-channel",
  "async-fs",
  "async-net",
+ "async-stream",
  "futures-lite",
  "futures-util",
  "nix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "odilia-input"
-version = "0.0.3"
+version = "0.3.0"
 dependencies = [
  "async-channel",
  "async-fs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,6 +1814,8 @@ name = "odilia-input"
 version = "0.0.3"
 dependencies = [
  "async-channel",
+ "futures",
+ "futures-lite",
  "nix",
  "odilia-common",
  "serde_json",
@@ -1869,6 +1871,8 @@ name = "odilia-tts"
 version = "0.1.4"
 dependencies = [
  "async-channel",
+ "futures",
+ "futures-lite",
  "odilia-common",
  "smol-cancellation-token",
  "ssip-client-async",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,12 +39,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
-name = "anyhow"
-version = "1.0.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-
-[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,28 +183,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,53 +258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,18 +271,6 @@ dependencies = [
  "rustc-demangle",
  "windows-targets",
 ]
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
@@ -557,45 +470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console-api"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
-dependencies = [
- "futures-core",
- "prost",
- "prost-types",
- "tonic",
- "tracing-core",
-]
-
-[[package]]
-name = "console-subscriber"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6539aa9c6a4cd31f4b1c040f860a1eac9aa80e7df6b05d506a6e7179936d6a01"
-dependencies = [
- "console-api",
- "crossbeam-channel",
- "crossbeam-utils",
- "futures-task",
- "hdrhistogram",
- "humantime",
- "hyper-util",
- "prost",
- "prost-types",
- "serde",
- "serde_json",
- "thread_local",
- "tokio",
- "tokio-stream",
- "tonic",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "cordyceps"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,15 +536,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "criterion"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,15 +567,6 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -753,7 +609,7 @@ dependencies = [
  "cfg-if",
  "crossbeam-utils",
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown",
  "lock_api",
  "parking_lot_core",
  "serde",
@@ -862,12 +718,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_home"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
-
-[[package]]
 name = "epoll"
 version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,16 +794,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "flate2"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,15 +825,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "spin",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
 ]
 
 [[package]]
@@ -1032,12 +863,6 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -1110,25 +935,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "h2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap 2.9.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,28 +946,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
-
-[[package]]
-name = "hdrhistogram"
-version = "7.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
-dependencies = [
- "base64 0.21.7",
- "byteorder",
- "flate2",
- "nom",
- "num-traits",
-]
 
 [[package]]
 name = "heck"
@@ -1182,130 +969,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "http"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
-
-[[package]]
-name = "hyper"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "libc",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1491,12 +1161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,18 +1174,6 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1554,16 +1206,6 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1686,7 +1328,6 @@ version = "0.1.4"
 dependencies = [
  "async-channel",
  "async-executor",
- "async-io",
  "async-signal",
  "atspi",
  "atspi-common",
@@ -1694,12 +1335,10 @@ dependencies = [
  "atspi-proxies",
  "circular-queue",
  "config",
- "console-subscriber",
  "derived-deref",
  "futures-concurrency",
  "futures-lite",
  "futures-util",
- "lazy_static",
  "lexopt",
  "odilia-cache",
  "odilia-common",
@@ -1709,19 +1348,16 @@ dependencies = [
  "odilia-tts",
  "pin-project",
  "refinement",
- "smol",
  "smol-cancellation-token",
  "ssip",
  "ssip-client-async",
- "tokio",
- "tower 0.5.2",
+ "tower",
  "tower-iter",
  "tracing",
  "tracing-error",
  "tracing-journald",
  "tracing-subscriber",
  "tracing-tree",
- "which",
  "xdg",
  "zbus",
 ]
@@ -1746,6 +1382,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
+ "tokio",
  "tracing",
  "zbus",
 ]
@@ -1830,7 +1467,7 @@ dependencies = [
  "pin-project-lite",
  "ssip",
  "static_assertions",
- "tower 0.5.2",
+ "tower",
 ]
 
 [[package]]
@@ -1914,12 +1551,6 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
@@ -2064,38 +1695,6 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
-]
-
-[[package]]
-name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
-dependencies = [
- "prost",
 ]
 
 [[package]]
@@ -2687,30 +2286,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "toml"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,61 +2312,11 @@ version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "winnow",
-]
-
-[[package]]
-name = "tonic"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.22.1",
- "bytes",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost",
- "socket2",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2815,7 +2340,7 @@ dependencies = [
  "futures-lite",
  "futures-util",
  "pin-project-lite",
- "tower 0.5.2",
+ "tower",
 ]
 
 [[package]]
@@ -2925,12 +2450,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
 name = "uds_windows"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2982,15 +2501,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
 ]
 
 [[package]]
@@ -3074,18 +2584,6 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "which"
-version = "7.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
-dependencies = [
- "either",
- "env_home",
- "rustix",
- "winsafe",
 ]
 
 [[package]]
@@ -3329,12 +2827,6 @@ checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,17 +1034,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,11 +1052,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
- "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -1725,8 +1712,6 @@ dependencies = [
  "ssip",
  "ssip-client-async",
  "tokio",
- "tokio-test",
- "tokio-util",
  "tower 0.5.2",
  "tower-iter",
  "tracing",
@@ -2695,19 +2680,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-test"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
-dependencies = [
- "async-stream",
- "bytes",
- "futures-core",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2716,8 +2688,6 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "futures-util",
- "hashbrown 0.15.3",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,12 +340,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "bytes"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,17 +1179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
-dependencies = [
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,7 +1329,7 @@ dependencies = [
  "odilia-notify",
  "odilia-tower",
  "odilia-tts",
- "pin-project",
+ "pin-project-lite",
  "refinement",
  "smol-cancellation-token",
  "ssip",
@@ -1393,21 +1376,22 @@ version = "0.3.0"
 dependencies = [
  "async-channel",
  "atspi",
+ "config",
  "enum_dispatch",
  "futures-concurrency",
  "futures-util",
  "indextree",
+ "lexopt",
  "serde",
  "serde_plain",
  "ssip",
+ "ssip-client-async",
  "strum",
  "thiserror",
  "tokio",
  "tracing",
  "xdg",
  "zbus",
- "zbus_names",
- "zvariant",
 ]
 
 [[package]]
@@ -1447,6 +1431,7 @@ dependencies = [
  "futures-lite",
  "itertools 0.14.0",
  "notify-rust",
+ "odilia-common",
  "serde",
  "thiserror",
  "tokio",
@@ -1478,6 +1463,7 @@ dependencies = [
  "async-net",
  "futures-lite",
  "futures-util",
+ "odilia-common",
  "smol-cancellation-token",
  "ssip-client-async",
  "tracing",
@@ -2074,16 +2060,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2263,15 +2239,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
- "bytes",
- "libc",
- "mio",
  "pin-project-lite",
- "signal-hook-registry",
- "socket2",
  "tokio-macros",
- "tracing",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2867,7 +2836,6 @@ dependencies = [
  "ordered-stream",
  "serde",
  "serde_repr",
- "tokio",
  "tracing",
  "uds_windows",
  "windows-sys 0.59.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,12 +1896,14 @@ name = "odilia-tts"
 version = "0.1.4"
 dependencies = [
  "async-channel",
+ "async-fs",
+ "async-io",
+ "async-net",
  "futures",
  "futures-lite",
  "odilia-common",
  "smol-cancellation-token",
  "ssip-client-async",
- "tokio",
  "tracing",
 ]
 
@@ -2548,8 +2550,6 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 [[package]]
 name = "ssip"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff83642a89ed3f8266199fbc335e17f85c95ac418d6ae788ccb6243dcc9a519"
 dependencies = [
  "serde",
  "strum_macros",
@@ -2559,14 +2559,13 @@ dependencies = [
 
 [[package]]
 name = "ssip-client-async"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1e3671cd925284e4fd591c73a5deb77741ee1a762b63af5190290d6887c239"
+version = "0.17.0"
 dependencies = [
+ "async-net",
  "dirs",
+ "futures-lite",
  "log",
  "ssip",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,7 +988,6 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1035,17 +1034,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -1839,8 +1827,8 @@ dependencies = [
  "async-channel",
  "async-fs",
  "async-net",
- "futures",
  "futures-lite",
+ "futures-util",
  "nix",
  "odilia-common",
  "serde_json",
@@ -1866,7 +1854,7 @@ dependencies = [
 name = "odilia-notify"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures-lite",
  "itertools 0.14.0",
  "notify-rust",
  "serde",
@@ -1882,7 +1870,8 @@ name = "odilia-tower"
 version = "0.1.0"
 dependencies = [
  "assert_matches",
- "futures",
+ "async-io",
+ "futures-lite",
  "futures-util",
  "odilia-common",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,27 +658,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c"
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "dispatch2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,16 +1056,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags 2.9.1",
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,12 +1442,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,17 +1762,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror",
-]
-
-[[package]]
 name = "refinement"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,14 +2021,12 @@ dependencies = [
 
 [[package]]
 name = "ssip-client-async"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8e1afa81c809cbec25fc81f073895c03316d9246b90835536610ef8b69ca22"
+checksum = "2d6df0f63d20f5c99989248b30fcc5c95ec687a30f44b88c9299c2caaf3ee875"
 dependencies = [
  "async-net",
- "dirs",
  "futures-lite",
- "log",
  "ssip",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ name = "atspi"
 version = "0.27.0"
 dependencies = [
  "atspi-common",
+ "atspi-connection",
  "atspi-proxies",
 ]
 
@@ -933,17 +934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "evmap"
-version = "10.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3ea06a83f97d3dc2eb06e51e7a729b418f0717a5558a5c870e3d5156dc558d"
-dependencies = [
- "hashbag",
- "slab",
- "smallvec",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,12 +1146,6 @@ dependencies = [
  "cfg-if",
  "crunchy",
 ]
-
-[[package]]
-name = "hashbag"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f494b2060b2a8f5e63379e1e487258e014cee1b1725a735816c0107a2e9d93"
 
 [[package]]
 name = "hashbrown"
@@ -1757,11 +1741,9 @@ version = "0.3.0"
 dependencies = [
  "atspi",
  "atspi-common",
- "atspi-connection",
  "atspi-proxies",
  "criterion",
  "dashmap",
- "evmap",
  "futures-concurrency",
  "futures-lite",
  "futures-util",
@@ -1822,7 +1804,7 @@ dependencies = [
 name = "odilia-input-server-keyboard"
 version = "0.1.0"
 dependencies = [
- "atspi-common",
+ "atspi",
  "nix",
  "odilia-common",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,24 +1000,8 @@ version = "4.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb9e21e48c85fa6643a38caca564645a3bbc9211edf506fc8ed690c7e7b4d3c7"
 dependencies = [
- "indextree-macros",
  "rayon",
  "serde",
-]
-
-[[package]]
-name = "indextree-macros"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85dac6c239acc85fd61934c572292d93adfd2de459d9c032aa22b553506e915"
-dependencies = [
- "either",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "strum",
- "syn",
- "thiserror",
 ]
 
 [[package]]
@@ -1381,7 +1365,6 @@ dependencies = [
  "futures-util",
  "fxhash",
  "indextree",
- "itertools 0.14.0",
  "odilia-common",
  "parking_lot",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,16 +942,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "evmap"
+version = "10.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e3ea06a83f97d3dc2eb06e51e7a729b418f0717a5558a5c870e3d5156dc558d"
+dependencies = [
+ "hashbag",
+ "slab",
+ "smallvec",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1191,6 +1196,12 @@ dependencies = [
  "cfg-if",
  "crunchy",
 ]
+
+[[package]]
+name = "hashbag"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98f494b2060b2a8f5e63379e1e487258e014cee1b1725a735816c0107a2e9d93"
 
 [[package]]
 name = "hashbrown"
@@ -1790,6 +1801,7 @@ dependencies = [
  "atspi-proxies",
  "criterion",
  "dashmap",
+ "evmap",
  "futures",
  "futures-concurrency",
  "futures-lite",
@@ -1957,13 +1969,10 @@ version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
- "backtrace",
  "cfg-if",
  "libc",
- "petgraph",
  "redox_syscall",
  "smallvec",
- "thread-id",
  "windows-targets",
 ]
 
@@ -1978,16 +1987,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.9.0",
-]
 
 [[package]]
 name = "pin-project"
@@ -2664,16 +2663,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thread-id"
-version = "4.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "atspi"
 version = "0.27.0"
+source = "git+https://github.com/odilia-app/atspi?branch=no-default-features-common#ff47522e9e87e4f2ba98d418b12968519b31d57e"
 dependencies = [
  "atspi-common",
  "atspi-connection",
@@ -245,6 +246,7 @@ dependencies = [
 [[package]]
 name = "atspi-common"
 version = "0.11.0"
+source = "git+https://github.com/odilia-app/atspi?branch=no-default-features-common#ff47522e9e87e4f2ba98d418b12968519b31d57e"
 dependencies = [
  "enumflags2",
  "serde",
@@ -259,6 +261,7 @@ dependencies = [
 [[package]]
 name = "atspi-connection"
 version = "0.11.0"
+source = "git+https://github.com/odilia-app/atspi?branch=no-default-features-common#ff47522e9e87e4f2ba98d418b12968519b31d57e"
 dependencies = [
  "atspi-common",
  "atspi-proxies",
@@ -269,6 +272,7 @@ dependencies = [
 [[package]]
 name = "atspi-proxies"
 version = "0.11.0"
+source = "git+https://github.com/odilia-app/atspi?branch=no-default-features-common#ff47522e9e87e4f2ba98d418b12968519b31d57e"
 dependencies = [
  "atspi-common",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ name = "atspi"
 version = "0.27.0"
 dependencies = [
  "atspi-common",
+ "atspi-proxies",
 ]
 
 [[package]]
@@ -260,6 +261,7 @@ version = "0.11.0"
 dependencies = [
  "atspi-common",
  "atspi-proxies",
+ "futures-lite",
  "zbus",
 ]
 
@@ -1895,8 +1897,8 @@ version = "0.1.4"
 dependencies = [
  "async-channel",
  "async-net",
- "futures",
  "futures-lite",
+ "futures-util",
  "smol-cancellation-token",
  "ssip-client-async",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,15 +1043,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,6 +1375,7 @@ dependencies = [
  "config",
  "enum_dispatch",
  "futures-concurrency",
+ "futures-lite",
  "futures-util",
  "indextree",
  "lexopt",
@@ -1435,7 +1427,6 @@ name = "odilia-notify"
 version = "0.1.0"
 dependencies = [
  "futures-lite",
- "itertools 0.14.0",
  "notify-rust",
  "odilia-common",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,9 +1310,6 @@ dependencies = [
  "async-executor",
  "async-signal",
  "atspi",
- "atspi-common",
- "atspi-connection",
- "atspi-proxies",
  "circular-queue",
  "config",
  "derived-deref",
@@ -1347,8 +1344,6 @@ name = "odilia-cache"
 version = "0.3.0"
 dependencies = [
  "atspi",
- "atspi-common",
- "atspi-proxies",
  "criterion",
  "dashmap",
  "futures-concurrency",
@@ -1375,7 +1370,6 @@ dependencies = [
  "config",
  "enum_dispatch",
  "futures-concurrency",
- "futures-lite",
  "futures-util",
  "indextree",
  "lexopt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,8 +689,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "smol",
  "tinytemplate",
- "tokio",
  "walkdir",
 ]
 
@@ -1744,7 +1744,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
- "tokio",
  "tracing",
  "zbus",
 ]
@@ -2445,6 +2444,23 @@ name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+
+[[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
 
 [[package]]
 name = "smol-cancellation-token"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2405,7 +2405,6 @@ checksum = "f459ca79f1b0d5f71c54ddfde6debfc59c8b6eeb46808ae492077f739dc7b49c"
 dependencies = [
  "nu-ansi-term 0.50.1",
  "tracing-core",
- "tracing-log",
  "tracing-subscriber",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,6 +2486,8 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 [[package]]
 name = "ssip"
 version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff83642a89ed3f8266199fbc335e17f85c95ac418d6ae788ccb6243dcc9a519"
 dependencies = [
  "serde",
  "strum_macros",
@@ -2495,6 +2497,8 @@ dependencies = [
 [[package]]
 name = "ssip-client-async"
 version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac8e1afa81c809cbec25fc81f073895c03316d9246b90835536610ef8b69ca22"
 dependencies = [
  "async-net",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,6 +1685,7 @@ name = "odilia"
 version = "0.1.4"
 dependencies = [
  "async-channel",
+ "async-executor",
  "async-io",
  "async-signal",
  "atspi",
@@ -1708,6 +1709,7 @@ dependencies = [
  "odilia-tts",
  "pin-project",
  "refinement",
+ "smol",
  "smol-cancellation-token",
  "ssip",
  "ssip-client-async",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +127,17 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -1814,6 +1836,9 @@ name = "odilia-input"
 version = "0.0.3"
 dependencies = [
  "async-channel",
+ "async-fs",
+ "async-io",
+ "async-net",
  "futures",
  "futures-lite",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ atspi = { version = "0.27.0", git = "https://github.com/odilia-app/atspi", branc
 atspi-proxies = { version = "0.11.0", git = "https://github.com/odilia-app/atspi", branch = "no-default-features-common", default-features = false }
 atspi-common = { version = "0.11.0", git = "https://github.com/odilia-app/atspi", branch = "no-default-features-common", default-features = false }
 atspi-connection = { version = "0.11.0", git = "https://github.com/odilia-app/atspi", branch = "no-default-features-common", default-features = false }
+config = { version = "0.15.11", default-features = false, features = ["toml"] }
 futures-concurrency = { version = "7.6.1", default-features = false }
 futures-lite = { version = "2.6.0", default-features = false }
 futures-util = { version = "0.3.31", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,6 @@ tracing-tree = { version = "^0.4.0", default-features = false }
 zbus = { version = "5.1", default-features = false, features = ["async-io"] }
 serde_plain = "1.0.1"
 ssip = { version = "0.4", default-features = false }
-ssip-client-async = { version = "0.17.0", default-features = false, features = ["async-io"] }
+ssip-client-async = { version = "0.18.0", default-features = false, features = ["async-io"] }
 
 xdg = { version = "2.5.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,9 @@ async-net = { version = "2.0", default-features = false }
 async-io = { version = "2.0", default-features = false }
 async-channel = { version = "2.0", default-features = false }
 async-fs = { version = "2.0", default-features = false }
-odilia-common = { version = "0.3.0", path = "./common", default-features = false }
+odilia-common = { version = "0.3.0", path = "./common", features = ["async-io"] }
 odilia-cache = { version = "0.3.0", path = "./cache" }
 nix = { version = "0.30.0", default-features = false, features = ["user"] }
-pin-project = { version = "1.0", default-features = false }
 pin-project-lite = { version = "0.2.16", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ zbus = { version = "5.1", default-features = false, features = ["async-io"] }
 zvariant = "5.0"
 zbus_names = "4.0"
 serde_plain = "1.0.1"
-ssip = { version = "0.4", path = "../ssip-client-async/ssip/", default-features = false }
-ssip-client-async = { version = "0.17.0", path = "../ssip-client-async/ssip-client-async/", default-features = false, features = ["async-io"] }
+ssip = { version = "0.4", default-features = false }
+ssip-client-async = { version = "0.17.0", default-features = false, features = ["async-io"] }
 
 xdg = { version = "2.5.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,10 @@ atspi-common = { version = "0.11.0",  path = "../atspi/atspi-common", default-fe
 atspi-connection = { version = "0.11.0",  path = "../atspi/atspi-connection", default-features = false }
 futures-concurrency = { version = "7.6.1", default-features = false }
 futures = { version = "0.3.31", default-features = false, features = ["std"] }
+futures-lite = { version = "2.6.0", default-features = false }
 futures-util = { version = "0.3.31", default-features = false }
+async-net = { version = "2.0", default-features = false }
+async-channel = { version = "2.0", default-features = false }
 odilia-common = { version = "0.3.0", path = "./common", default-features = false }
 odilia-cache = { version = "0.3.0", path = "./cache" }
 nix = { version = "0.30.0", default-features = false, features = ["user"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ async-net = { version = "2.0", default-features = false }
 async-io = { version = "2.0", default-features = false }
 async-channel = { version = "2.0", default-features = false }
 async-fs = { version = "2.0", default-features = false }
+lexopt = { version = "0.3.1", default-features = false }
 odilia-common = { version = "0.3.0", path = "./common", features = ["async-io"] }
 odilia-cache = { version = "0.3.0", path = "./cache" }
 nix = { version = "0.30.0", default-features = false, features = ["user"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ pin-project = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "2.0", default-features = false }
-tokio = { version = "^1.22.0", default-features = false, features = ["macros", "rt", "tracing", "fs", "net", "sync"] }
+tokio = { version = "^1.22.0", default-features = false, features = ["macros", "rt", "tracing", "net", "sync"] }
 tokio-util = { version = "0.7.10", default-features = false, features = ["rt"] }
 smol-cancellation-token = { version = "0.1", default-features = false }
 tower = { version = "0.5.2", features = ["util", "filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,7 @@ pre-release-hook = ["cargo", "fmt"]
 dependent-version = "upgrade"
 
 [workspace.dependencies]
-atspi = { version = "0.27.0", git = "https://github.com/odilia-app/atspi", branch = "no-default-features-common", default-features = false }
-atspi-proxies = { version = "0.11.0", git = "https://github.com/odilia-app/atspi", branch = "no-default-features-common", default-features = false }
-atspi-common = { version = "0.11.0", git = "https://github.com/odilia-app/atspi", branch = "no-default-features-common", default-features = false }
-atspi-connection = { version = "0.11.0", git = "https://github.com/odilia-app/atspi", branch = "no-default-features-common", default-features = false }
+atspi = { version = "0.27.0", git = "https://github.com/odilia-app/atspi", branch = "no-default-features-common" }
 config = { version = "0.15.11", default-features = false, features = ["toml"] }
 futures-concurrency = { version = "7.6.1", default-features = false }
 futures-lite = { version = "2.6.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ pin-project = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "2.0", default-features = false }
-tokio = { version = "^1.22.0", default-features = false, features = ["macros", "rt", "tracing", "net", "sync"] }
+tokio = { version = "^1.22.0", default-features = false, features = ["macros", "rt", "tracing", "sync"] }
 tokio-util = { version = "0.7.10", default-features = false, features = ["rt"] }
 smol-cancellation-token = { version = "0.1", default-features = false }
 tower = { version = "0.5.2", features = ["util", "filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ atspi-proxies = { version = "0.11.0", git = "https://github.com/odilia-app/atspi
 atspi-common = { version = "0.11.0", git = "https://github.com/odilia-app/atspi", branch = "no-default-features-common", default-features = false }
 atspi-connection = { version = "0.11.0", git = "https://github.com/odilia-app/atspi", branch = "no-default-features-common", default-features = false }
 futures-concurrency = { version = "7.6.1", default-features = false }
-futures = { version = "0.3.31", default-features = false, features = ["std"] }
 futures-lite = { version = "2.6.0", default-features = false }
 futures-util = { version = "0.3.31", default-features = false }
 async-net = { version = "2.0", default-features = false }
@@ -51,8 +50,7 @@ pin-project-lite = { version = "0.2.16", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "2.0", default-features = false }
-tokio = { version = "^1.22.0", default-features = false, features = ["macros", "rt", "tracing", "sync"] }
-tokio-util = { version = "0.7.10", default-features = false, features = ["rt"] }
+tokio = { version = "^1.22.0", default-features = false, features = ["macros", "rt"] }
 smol-cancellation-token = { version = "0.1", default-features = false }
 tower = { version = "0.5.2", default-features = false }
 tracing = { version = "^0.1.37", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ tower = { version = "0.5.2", default-features = false }
 tracing = { version = "^0.1.37", default-features = false }
 tracing-subscriber = { version = "0.3.16", default-features = false }
 tracing-error = "^0.2.0"
-tracing-tree = "^0.4.0"
+tracing-tree = { version = "^0.4.0", default-features = false }
 zbus = { version = "5.1", default-features = false, features = ["async-io"] }
 serde_plain = "1.0.1"
 ssip = { version = "0.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ tracing-error = "^0.2.0"
 tracing-tree = "^0.4.0"
 zbus = { version = "5.1", default-features = false, features = ["async-io"] }
 serde_plain = "1.0.1"
-ssip = { version = "0.4", default-features = false }
-ssip-client-async = { version = "0.16.0", default-features = false, features = ["tokio"] }
+ssip = { version = "0.4", path = "../ssip-client-async/ssip/", default-features = false }
+ssip-client-async = { version = "0.17.0", path = "../ssip-client-async/ssip-client-async/", default-features = false, features = ["async-io"] }
 
 xdg = { version = "2.5.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ pre-release-hook = ["cargo", "fmt"]
 dependent-version = "upgrade"
 
 [workspace.dependencies]
-atspi = { version = "0.27.0", path = "../atspi/atspi", default-features = false }
-atspi-proxies = { version = "0.11.0", path = "../atspi/atspi-proxies", default-features = false }
-atspi-common = { version = "0.11.0",  path = "../atspi/atspi-common", default-features = false }
-atspi-connection = { version = "0.11.0",  path = "../atspi/atspi-connection", default-features = false }
+atspi = { version = "0.27.0", git = "https://github.com/odilia-app/atspi", branch = "no-default-features-common", default-features = false }
+atspi-proxies = { version = "0.11.0", git = "https://github.com/odilia-app/atspi", branch = "no-default-features-common", default-features = false }
+atspi-common = { version = "0.11.0", git = "https://github.com/odilia-app/atspi", branch = "no-default-features-common", default-features = false }
+atspi-connection = { version = "0.11.0", git = "https://github.com/odilia-app/atspi", branch = "no-default-features-common", default-features = false }
 futures-concurrency = { version = "7.6.1", default-features = false }
 futures = { version = "0.3.31", default-features = false, features = ["std"] }
 futures-lite = { version = "2.6.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver="2"
-default-members = ["odilia", "odilia-notify"]
+default-members = ["odilia"]
 members = [
   "cache",
   "common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,6 @@ tracing-subscriber = { version = "0.3.16", default-features = false }
 tracing-error = "^0.2.0"
 tracing-tree = "^0.4.0"
 zbus = { version = "5.1", default-features = false, features = ["async-io"] }
-zvariant = "5.0"
-zbus_names = "4.0"
 serde_plain = "1.0.1"
 ssip = { version = "0.4", default-features = false }
 ssip-client-async = { version = "0.17.0", default-features = false, features = ["async-io"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,28 +31,32 @@ pre-release-hook = ["cargo", "fmt"]
 dependent-version = "upgrade"
 
 [workspace.dependencies]
-atspi = { version = "0.27.0", default-features = false, features = ["proxies", "connection"] }
-atspi-proxies = { version = "0.11.0", default-features = false }
-atspi-common = { version = "0.11.0", default-features = false }
-atspi-connection = { version = "0.11.0", default-features = false }
+atspi = { version = "0.27.0", path = "../atspi/atspi", default-features = false }
+atspi-proxies = { version = "0.11.0", path = "../atspi/atspi-proxies", default-features = false }
+atspi-common = { version = "0.11.0",  path = "../atspi/atspi-common", default-features = false }
+atspi-connection = { version = "0.11.0",  path = "../atspi/atspi-connection", default-features = false }
 futures-concurrency = { version = "7.6.1", default-features = false }
 futures = { version = "0.3.31", default-features = false, features = ["std"] }
-odilia-common = { version = "0.3.0", path = "./common" }
+futures-util = { version = "0.3.31", default-features = false }
+odilia-common = { version = "0.3.0", path = "./common", default-features = false }
 odilia-cache = { version = "0.3.0", path = "./cache" }
 nix = { version = "0.30.0", default-features = false, features = ["user"] }
 pin-project = { version = "1.0", default-features = false }
+pin-project-lite = { version = "0.2.16", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "2.0", default-features = false }
 tokio = { version = "^1.22.0", default-features = false, features = ["macros", "rt", "tracing", "sync"] }
 tokio-util = { version = "0.7.10", default-features = false, features = ["rt"] }
 smol-cancellation-token = { version = "0.1", default-features = false }
-tower = { version = "0.5.2", features = ["util", "filter"] }
+tower = { version = "0.5.2", default-features = false }
 tracing = { version = "^0.1.37", default-features = false }
 tracing-subscriber = { version = "0.3.16", default-features = false }
 tracing-error = "^0.2.0"
 tracing-tree = "^0.4.0"
 zbus = { version = "5.1", default-features = false, features = ["async-io"] }
+zvariant = "5.0"
+zbus_names = "4.0"
 serde_plain = "1.0.1"
 ssip = { version = "0.4", path = "../ssip-client-async/ssip/", default-features = false }
 ssip-client-async = { version = "0.17.0", path = "../ssip-client-async/ssip-client-async/", default-features = false, features = ["async-io"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,9 @@ futures = { version = "0.3.31", default-features = false, features = ["std"] }
 futures-lite = { version = "2.6.0", default-features = false }
 futures-util = { version = "0.3.31", default-features = false }
 async-net = { version = "2.0", default-features = false }
+async-io = { version = "2.0", default-features = false }
 async-channel = { version = "2.0", default-features = false }
+async-fs = { version = "2.0", default-features = false }
 odilia-common = { version = "0.3.0", path = "./common", default-features = false }
 odilia-cache = { version = "0.3.0", path = "./cache" }
 nix = { version = "0.30.0", default-features = false, features = ["user"] }

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To build odilia, copy paste the following on your command line . The following s
 ```shell
 git clone https://github.com/odilia-app/odilia  && \
 cd odilia && \
+cargo install --path input-server-keyboard && \
 cargo install --path odilia
 ```
 

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["accessibility"]
 atspi.workspace = true
 atspi-proxies.workspace = true
 atspi-common.workspace = true
-odilia-common = { workspace = true, features = ["async-io"] }
+odilia-common.workspace = true
 dashmap = { version = "7.0.0-rc2", features = ["serde"] }
 serde.workspace = true
 tracing.workspace = true
@@ -26,7 +26,7 @@ indextree = { version = "4.7.4", features = ["rayon", "par_iter", "serde", "dese
 parking_lot = { version = "0.12.3", default-features = false }
 itertools = "0.14.0"
 futures-concurrency.workspace = true
-futures-lite = { version = "2.6.0", default-features = false }
+futures-lite.workspace = true
 
 [dev-dependencies]
 atspi = { workspace = true, features = ["connection"] }

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["accessibility"]
 atspi.workspace = true
 atspi-proxies.workspace = true
 atspi-common.workspace = true
-odilia-common.workspace = true
+odilia-common = { workspace = true, features = ["async-io"] }
 dashmap = { version = "7.0.0-rc2", features = ["serde"] }
 serde.workspace = true
 tracing.workspace = true

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -33,6 +33,7 @@ atspi = { workspace = true, features = ["connection"] }
 criterion = { version = "0.6.0", features = ["async_smol", "html_reports"] }
 futures-util = { workspace = true, features = ["alloc"] }
 serde_json.workspace = true
+tokio.workspace = true
 
 [[bench]]
 name = "load_test"

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -30,10 +30,9 @@ futures-lite = { version = "2.6.0", default-features = false }
 
 [dev-dependencies]
 atspi = { workspace = true, features = ["connection"] }
-criterion = { version = "0.6.0", features = ["async_tokio", "html_reports"] }
+criterion = { version = "0.6.0", features = ["async_smol", "html_reports"] }
 futures-util = { workspace = true, features = ["alloc"] }
 serde_json.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [[bench]]
 name = "load_test"

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -22,9 +22,8 @@ tracing.workspace = true
 zbus.workspace = true
 fxhash = "0.2.1"
 serde_plain.workspace = true
-indextree = { version = "4.7.4", features = ["rayon", "par_iter", "serde", "deser"] }
+indextree = { version = "4.7.4", default-features = false, features = ["rayon", "par_iter", "serde", "deser"] }
 parking_lot = { version = "0.12.3", default-features = false }
-itertools = "0.14.0"
 futures-concurrency.workspace = true
 futures-lite.workspace = true
 

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -23,16 +23,15 @@ zbus.workspace = true
 fxhash = "0.2.1"
 serde_plain.workspace = true
 indextree = { version = "4.7.4", features = ["rayon", "par_iter", "serde", "deser"] }
-evmap = "10.0.2"
 parking_lot = { version = "0.12.3", default-features = false }
 itertools = "0.14.0"
 futures-concurrency.workspace = true
 futures-lite = { version = "2.6.0", default-features = false }
 
 [dev-dependencies]
-atspi-connection.workspace = true
+atspi = { workspace = true, features = ["connection"] }
 criterion = { version = "0.6.0", features = ["async_tokio", "html_reports"] }
-futures-util.workspace = true
+futures-util = { workspace = true, features = ["alloc"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -32,7 +32,7 @@ futures-lite = { version = "2.6.0", default-features = false }
 [dev-dependencies]
 atspi-connection.workspace = true
 criterion = { version = "0.6.0", features = ["async_tokio", "html_reports"] }
-futures.workspace = true
+futures-util.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -13,8 +13,6 @@ categories = ["accessibility"]
 
 [dependencies]
 atspi.workspace = true
-atspi-proxies.workspace = true
-atspi-common.workspace = true
 odilia-common.workspace = true
 dashmap = { version = "7.0.0-rc2", features = ["serde"] }
 serde.workspace = true

--- a/cache/benches/load_test.rs
+++ b/cache/benches/load_test.rs
@@ -1,6 +1,6 @@
 use std::{collections::VecDeque, hint::black_box, sync::Arc, time::Duration};
 
-use atspi_connection::AccessibilityConnection;
+use atspi::connection::AccessibilityConnection;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use futures_concurrency::{array::AggregateError, future::RaceOk};
 use futures_lite::future::{block_on, fuse};

--- a/cache/benches/load_test.rs
+++ b/cache/benches/load_test.rs
@@ -2,7 +2,7 @@ use std::{collections::VecDeque, hint::black_box, sync::Arc, time::Duration};
 
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use futures_concurrency::{array::AggregateError, future::RaceOk};
-use futures_lite::future::{fuse, Future};
+use futures_lite::future::fuse;
 use indextree::{Arena, NodeId};
 use odilia_cache::{Cache, CacheDriver, CacheItem, CacheKey};
 use odilia_common::{cache::AccessiblePrimitive, errors::OdiliaError, result::OdiliaResult};
@@ -16,13 +16,8 @@ macro_rules! load_items {
 pub struct TestDriver;
 
 impl CacheDriver for TestDriver {
-	fn lookup_external(
-		&self,
-		_key: &CacheKey,
-	) -> impl Future<Output = OdiliaResult<CacheItem>> + Send {
-		async {
-			panic!("This driver (NoDriver) should never be called!");
-		}
+	async fn lookup_external(&self, _key: &CacheKey) -> OdiliaResult<CacheItem> {
+		panic!("This driver (NoDriver) should never be called!");
 	}
 }
 

--- a/cache/benches/load_test.rs
+++ b/cache/benches/load_test.rs
@@ -10,12 +10,6 @@ use indextree::{Arena, NodeId};
 use odilia_cache::{Cache, CacheDriver, CacheItem, CacheKey};
 use odilia_common::{cache::AccessiblePrimitive, errors::OdiliaError, result::OdiliaResult};
 
-macro_rules! load_items {
-	($file:expr) => {
-		::serde_json::from_str(include_str!($file)).unwrap()
-	};
-}
-
 pub struct TestDriver;
 
 impl CacheDriver for TestDriver {
@@ -102,8 +96,11 @@ async fn reads_while_writing(
 }
 
 fn cache_benchmark(c: &mut Criterion) {
-	let zbus_items: Vec<CacheItem> = load_items!("./zbus_docs_cache_items.json");
-	let wcag_items: Vec<CacheItem> = load_items!("./wcag_cache_items.json");
+	let zbus_items: Vec<CacheItem> =
+		serde_json::from_str(include_str!("./zbus_docs_cache_items.json")).unwrap();
+
+	let wcag_items: Vec<CacheItem> =
+		serde_json::from_str(include_str!("./wcag_cache_items.json")).unwrap();
 
 	let mut group = c.benchmark_group("cache");
 	group.sample_size(200) // def 100

--- a/cache/benches/load_test.rs
+++ b/cache/benches/load_test.rs
@@ -2,11 +2,10 @@ use std::{collections::VecDeque, hint::black_box, sync::Arc, time::Duration};
 
 use atspi_connection::AccessibilityConnection;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
-use indextree::{Arena, NodeId};
-use odilia_cache::{Cache, CacheItem};
-
 use futures_concurrency::{array::AggregateError, future::RaceOk};
 use futures_lite::future::{block_on, fuse};
+use indextree::{Arena, NodeId};
+use odilia_cache::{Cache, CacheItem};
 use odilia_common::{cache::AccessiblePrimitive, errors::OdiliaError};
 
 macro_rules! load_items {

--- a/cache/examples/gen_json.rs
+++ b/cache/examples/gen_json.rs
@@ -31,7 +31,7 @@ const REGISTRY_PATH: &str = "/org/a11y/atspi/accessible/root";
 const ACCESSIBLE_INTERFACE: &str = "org.a11y.atspi.Accessible";
 const MAX_CHILDREN: i32 = 65536;
 
-async fn from_a11y_proxy(ap: AccessibleProxy<'_>) -> Result<Arc<Cache>> {
+async fn from_a11y_proxy(ap: AccessibleProxy<'_>) -> Result<Arc<Cache<Connection>>> {
 	let connection = ap.inner().connection().clone();
 	// Contains the processed `A11yNode`'s.
 	let cache = Arc::new(Cache::new(connection.clone()));

--- a/cache/examples/gen_json.rs
+++ b/cache/examples/gen_json.rs
@@ -18,7 +18,7 @@ use atspi::{
 	proxy::accessible::{AccessibleProxy, ObjectRefExt},
 	AccessibilityConnection,
 };
-use futures::future::try_join_all;
+use futures_util::future::try_join_all;
 use odilia_cache::{accessible_to_cache_item, Cache, CacheItem};
 use odilia_common::errors::{CacheError, OdiliaError};
 use serde_json::to_string;

--- a/cache/examples/gen_json.rs
+++ b/cache/examples/gen_json.rs
@@ -76,7 +76,7 @@ async fn get_registry_accessible<'a>(conn: &Connection) -> Result<AccessibleProx
 	Ok(registry)
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
 	set_session_accessibility(true).await?;
 	let a11y = AccessibilityConnection::new().await?;

--- a/cache/src/accessible_ext.rs
+++ b/cache/src/accessible_ext.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, future::Future};
 
-use atspi_common::{ObjectRef, RelationType, Role};
-use atspi_proxies::accessible::AccessibleProxy;
+use atspi::{proxy::accessible::AccessibleProxy, ObjectRef, RelationType, Role};
 
 use crate::{convertable::Convertable, AccessiblePrimitive, CacheProperties, OdiliaError};
 

--- a/cache/src/convertable.rs
+++ b/cache/src/convertable.rs
@@ -121,49 +121,49 @@ async fn convert_to_new_type<
 impl<'a, T: ProxyImpl<'a> + ProxyDefault + Sync> Convertable<'a> for T {
 	type Error = zbus::Error;
 	/* no guard due to assumption it is always possible */
-	async fn to_accessible(&self) -> zbus::Result<AccessibleProxy> {
+	async fn to_accessible(&self) -> zbus::Result<AccessibleProxy<'_>> {
 		convert_to_new_type(self).await
 	}
-	async fn to_action(&self) -> zbus::Result<ActionProxy> {
+	async fn to_action(&self) -> zbus::Result<ActionProxy<'_>> {
 		convert_to_new_type(self).await
 	}
-	async fn to_application(&self) -> zbus::Result<ApplicationProxy> {
+	async fn to_application(&self) -> zbus::Result<ApplicationProxy<'_>> {
 		convert_to_new_type(self).await
 	}
-	async fn to_collection(&self) -> zbus::Result<CollectionProxy> {
+	async fn to_collection(&self) -> zbus::Result<CollectionProxy<'_>> {
 		convert_to_new_type(self).await
 	}
-	async fn to_component(&self) -> zbus::Result<ComponentProxy> {
+	async fn to_component(&self) -> zbus::Result<ComponentProxy<'_>> {
 		convert_to_new_type(self).await
 	}
-	async fn to_document(&self) -> zbus::Result<DocumentProxy> {
+	async fn to_document(&self) -> zbus::Result<DocumentProxy<'_>> {
 		convert_to_new_type(self).await
 	}
-	async fn to_hypertext(&self) -> zbus::Result<HypertextProxy> {
+	async fn to_hypertext(&self) -> zbus::Result<HypertextProxy<'_>> {
 		convert_to_new_type(self).await
 	}
-	async fn to_hyperlink(&self) -> zbus::Result<HyperlinkProxy> {
+	async fn to_hyperlink(&self) -> zbus::Result<HyperlinkProxy<'_>> {
 		convert_to_new_type(self).await
 	}
-	async fn to_image(&self) -> zbus::Result<ImageProxy> {
+	async fn to_image(&self) -> zbus::Result<ImageProxy<'_>> {
 		convert_to_new_type(self).await
 	}
-	async fn to_selection(&self) -> zbus::Result<SelectionProxy> {
+	async fn to_selection(&self) -> zbus::Result<SelectionProxy<'_>> {
 		convert_to_new_type(self).await
 	}
-	async fn to_table(&self) -> zbus::Result<TableProxy> {
+	async fn to_table(&self) -> zbus::Result<TableProxy<'_>> {
 		convert_to_new_type(self).await
 	}
-	async fn to_table_cell(&self) -> zbus::Result<TableCellProxy> {
+	async fn to_table_cell(&self) -> zbus::Result<TableCellProxy<'_>> {
 		convert_to_new_type(self).await
 	}
-	async fn to_text(&self) -> zbus::Result<TextProxy> {
+	async fn to_text(&self) -> zbus::Result<TextProxy<'_>> {
 		convert_to_new_type(self).await
 	}
-	async fn to_editable_text(&self) -> zbus::Result<EditableTextProxy> {
+	async fn to_editable_text(&self) -> zbus::Result<EditableTextProxy<'_>> {
 		convert_to_new_type(self).await
 	}
-	async fn to_value(&self) -> zbus::Result<ValueProxy> {
+	async fn to_value(&self) -> zbus::Result<ValueProxy<'_>> {
 		convert_to_new_type(self).await
 	}
 }

--- a/cache/src/convertable.rs
+++ b/cache/src/convertable.rs
@@ -1,12 +1,14 @@
 use std::future::Future;
 
-use atspi::Interface;
-use atspi_proxies::{
-	accessible::AccessibleProxy, action::ActionProxy, application::ApplicationProxy,
-	collection::CollectionProxy, component::ComponentProxy, document::DocumentProxy,
-	editable_text::EditableTextProxy, hyperlink::HyperlinkProxy, hypertext::HypertextProxy,
-	image::ImageProxy, selection::SelectionProxy, table::TableProxy,
-	table_cell::TableCellProxy, text::TextProxy, value::ValueProxy,
+use atspi::{
+	proxy::{
+		accessible::AccessibleProxy, action::ActionProxy, application::ApplicationProxy,
+		collection::CollectionProxy, component::ComponentProxy, document::DocumentProxy,
+		editable_text::EditableTextProxy, hyperlink::HyperlinkProxy,
+		hypertext::HypertextProxy, image::ImageProxy, selection::SelectionProxy,
+		table::TableProxy, table_cell::TableCellProxy, text::TextProxy, value::ValueProxy,
+	},
+	Interface,
 };
 use zbus::{
 	names::InterfaceName,
@@ -24,7 +26,7 @@ pub trait Convertable<'a> {
 	/// This may fail based on the implementation of.
 	/// Generally, it fails if the accessible item does not implement to accessible interface.
 	/// This shouldn't be possible, but this function may fail for other reasons.
-	/// For example, to convert a [`zbus::Proxy`] into a [`AccessibleProxy`], it may fail to create the new [`atspi_proxies::accessible::AccessibleProxy`].
+	/// For example, to convert a [`zbus::Proxy`] into a [`AccessibleProxy`], it may fail to create the new [`atspi::proxy::accessible::AccessibleProxy`].
 	fn to_accessible(
 		&self,
 	) -> impl Future<Output = Result<AccessibleProxy, Self::Error>> + Send;

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -20,7 +20,6 @@ use dashmap::DashMap;
 use futures_concurrency::future::TryJoin;
 use fxhash::FxBuildHasher;
 use indextree::{Arena, NodeId};
-use itertools::Itertools;
 use odilia_common::{
 	cache::AccessiblePrimitive,
 	errors::{CacheError, OdiliaError},
@@ -478,7 +477,7 @@ pub async fn accessible_to_cache_item(accessible: &AccessibleProxy<'_>) -> Odili
 		role,
 		states,
 		text,
-		children: children.into_iter().map_into().collect(),
+		children: children.into_iter().map(Into::into).collect(),
 		relation_set: rs,
 		name,
 		description: desc,

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -14,8 +14,10 @@ mod accessible_ext;
 use std::{collections::VecDeque, fmt::Debug, future::Future, sync::Arc};
 
 pub use accessible_ext::AccessibleExt;
-use atspi_common::{EventProperties, InterfaceSet, ObjectRef, RelationType, Role, StateSet};
-use atspi_proxies::{accessible::AccessibleProxy, text::TextProxy};
+use atspi::{
+	proxy::{accessible::AccessibleProxy, text::TextProxy},
+	EventProperties, InterfaceSet, ObjectRef, RelationType, Role, StateSet,
+};
 use dashmap::DashMap;
 use futures_concurrency::future::TryJoin;
 use fxhash::FxBuildHasher;
@@ -118,7 +120,7 @@ impl From<Vec<(RelationType, Vec<Link>)>> for RelationSet {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-/// A struct representing an accessible. To get any information from the cache other than the stored information like role, interfaces, and states, you will need to instantiate an [`atspi_proxies::accessible::AccessibleProxy`] or other `*Proxy` type from atspi to query further info.
+/// A struct representing an accessible. To get any information from the cache other than the stored information like role, interfaces, and states, you will need to instantiate an [`atspi::proxy::accessible::AccessibleProxy`] or other `*Proxy` type from atspi to query further info.
 pub struct CacheItem {
 	/// The accessible object (within the application)    (so)
 	pub object: AccessiblePrimitive,
@@ -154,7 +156,7 @@ impl CacheItem {
 	/// This can fail under three possible conditions:
 	///
 	/// 1. We are unable to convert information from the event into an [`AccessiblePrimitive`] hashmap key. This should never happen.
-	/// 2. We are unable to convert the [`AccessiblePrimitive`] to an [`atspi_proxies::accessible::AccessibleProxy`].
+	/// 2. We are unable to convert the [`AccessiblePrimitive`] to an [`atspi::proxy::accessible::AccessibleProxy`].
 	/// 3. The `accessible_to_cache_item` function fails for any reason. This also shouldn't happen.
 	#[tracing::instrument(level = "trace", skip_all, ret, err)]
 	pub async fn from_atspi_event<T: EventProperties, E: CacheDriver>(
@@ -426,7 +428,7 @@ impl<D: CacheDriver> Cache<D> {
 	}
 }
 
-/// Convert an [`atspi_proxies::accessible::AccessibleProxy`] into a [`crate::CacheItem`].
+/// Convert an [`atspi::proxy::accessible::AccessibleProxy`] into a [`crate::CacheItem`].
 /// This runs a bunch of long-awaiting code and can take quite some time; use this sparingly.
 /// This takes most properties and some function calls through the `AccessibleProxy` structure and generates a new `CacheItem`, which will be written to cache before being sent back.
 ///

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -341,9 +341,9 @@ impl<D: CacheDriver> Cache<D> {
 	/// Bulk add many items to the cache; only one accessible should ever be
 	/// associated with an id.
 	/// # Errors
-	/// An `Err(_)` variant may be returned if the [`Cache::populate_references`] function fails.
-	// TODO: add ", err" back to instrumentqation
-	#[tracing::instrument(level = "trace", ret)]
+	/// An `Err(_)` variant may returned if the [`RelationSet`] fails to resolve to real IDs in the
+	/// cache.
+	#[tracing::instrument(level = "trace", ret, err)]
 	pub fn add_all(&self, cache_items: Vec<CacheItem>) -> OdiliaResult<()> {
 		for cache_item in cache_items {
 			let _ = self.add(cache_item);

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -22,6 +22,7 @@ pub use accessible_ext::AccessibleExt;
 use atspi_common::{EventProperties, InterfaceSet, ObjectRef, RelationType, Role, StateSet};
 use atspi_proxies::{accessible::AccessibleProxy, text::TextProxy};
 use dashmap::DashMap;
+use futures_concurrency::future::TryJoin;
 use fxhash::FxBuildHasher;
 use indextree::{Arena, NodeId};
 use itertools::Itertools;

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -11,12 +11,7 @@
 mod convertable;
 pub use convertable::Convertable;
 mod accessible_ext;
-use std::{
-	collections::{HashMap, VecDeque},
-	fmt::Debug,
-	future::Future,
-	sync::Arc,
-};
+use std::{collections::VecDeque, fmt::Debug, future::Future, sync::Arc};
 
 pub use accessible_ext::AccessibleExt;
 use atspi_common::{EventProperties, InterfaceSet, ObjectRef, RelationType, Role, StateSet};
@@ -223,7 +218,7 @@ pub trait CacheDriver {
 }
 
 impl CacheDriver for zbus::Connection {
-	#[tracing::instrument(level = "trace", ret, skip(self))]
+	#[tracing::instrument(level = "trace", ret, skip(self), fields(key.item, key.name))]
 	async fn lookup_external(&self, key: &CacheKey) -> OdiliaResult<CacheItem> {
 		let accessible = AccessibleProxy::builder(self)
 			.destination(key.sender.clone())?
@@ -232,13 +227,6 @@ impl CacheDriver for zbus::Connection {
 			.build()
 			.await?;
 		accessible_to_cache_item(&accessible).await
-	}
-}
-
-impl<S: std::hash::BuildHasher + Sync> CacheDriver for HashMap<CacheKey, CacheItem, S> {
-	#[tracing::instrument(level = "trace", ret, skip(self))]
-	async fn lookup_external(&self, key: &CacheKey) -> OdiliaResult<CacheItem> {
-		Ok(self.get(key).ok_or::<OdiliaError>(CacheError::NoItem.into())?.clone())
 	}
 }
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,21 +12,18 @@ categories = ["accessibility"]
 edition = "2021"
 
 [features]
-default = ["async-io"]
-tokio = ["dep:tokio", "zbus/tokio"]
-async-io = ["dep:async-channel", "zbus/async-io"]
+default = []
 tracing = ["dep:tracing"]
-zbus = ["atspi/proxies", "async-io"]
+async-io = ["dep:async-channel"]
+tokio = ["tokio/sync"]
 
 [dependencies]
-atspi = { workspace = true, default-features = false, features = ["wrappers"] }
+atspi = { workspace = true, default-features = false, features = ["wrappers", "proxies"] }
 futures-concurrency.workspace = true
 futures-util.workspace = true
 serde.workspace = true
 thiserror.workspace = true
-zbus = { workspace = true, optional = true }
-zbus_names.workspace = true
-zvariant.workspace = true
+zbus.workspace = true
 serde_plain.workspace = true
 enum_dispatch = "0.3.13"
 strum = { version = "0.27.1", features = ["derive"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,26 +13,26 @@ edition = "2021"
 
 [features]
 default = ["async-io"]
-tokio = ["dep:tokio"]
-async-io = ["dep:async-channel"]
+tokio = ["dep:tokio", "zbus/tokio"]
+async-io = ["dep:async-channel", "zbus/async-io"]
 tracing = ["dep:tracing"]
+zbus = []
 
 [dependencies]
-atspi.workspace = true
-atspi-common.workspace = true
-atspi-proxies.workspace = true
-futures.workspace = true
+atspi = { workspace = true, default-features = false, features = ["wrappers"] }
 futures-concurrency.workspace = true
+futures-util.workspace = true
 serde.workspace = true
 thiserror.workspace = true
-zbus.workspace = true
+zbus = { workspace = true, optional = true }
+zbus_names.workspace = true
+zvariant.workspace = true
 serde_plain.workspace = true
 enum_dispatch = "0.3.13"
 strum = { version = "0.27.1", features = ["derive"] }
 tokio = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
-ssip = { workspace = true, features = ["dbus"] }
+ssip = { workspace = true, default-features = false, features = ["serde"] }
 xdg.workspace = true
-zvariant = "5.4.0"
 indextree = { version = "4.7.4", default-features = false }
 async-channel = { version = "2.3.1", default-features = false, optional = true }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -22,6 +22,7 @@ atspi = { workspace = true, default-features = false, features = ["wrappers", "p
 futures-concurrency.workspace = true
 futures-util.workspace = true
 serde.workspace = true
+config.workspace = true
 thiserror.workspace = true
 zbus.workspace = true
 serde_plain.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2021"
 
 [features]
 default = ["async-io"]
-tokio = ["dep:tokio", "zbus/tokio"]
-async-io = ["dep:async-channel", "zbus/async-io"]
+tokio = ["dep:tokio", "zbus/tokio", "atspi/proxies"]
+async-io = ["dep:async-channel", "zbus/async-io", "atspi/proxies"]
 tracing = ["dep:tracing"]
 zbus = []
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,7 +18,7 @@ async-io = ["dep:async-channel"]
 tokio = ["tokio/sync"]
 
 [dependencies]
-atspi = { workspace = true, default-features = false, features = ["wrappers", "proxies"] }
+atspi.workspace = true
 futures-concurrency.workspace = true
 futures-util.workspace = true
 serde.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -27,10 +27,12 @@ thiserror.workspace = true
 zbus.workspace = true
 serde_plain.workspace = true
 enum_dispatch = "0.3.13"
+lexopt.workspace = true
 strum = { version = "0.27.1", features = ["derive"] }
 tokio = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true, features = ["attributes"] }
 ssip = { workspace = true, default-features = false, features = ["serde"] }
+ssip-client-async.workspace = true
 xdg.workspace = true
 indextree = { version = "4.7.4", default-features = false }
 async-channel = { version = "2.3.1", default-features = false, optional = true }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2021"
 
 [features]
 default = ["async-io"]
-tokio = ["dep:tokio", "zbus/tokio", "atspi/proxies"]
-async-io = ["dep:async-channel", "zbus/async-io", "atspi/proxies"]
+tokio = ["dep:tokio", "zbus/tokio"]
+async-io = ["dep:async-channel", "zbus/async-io"]
 tracing = ["dep:tracing"]
-zbus = []
+zbus = ["atspi/proxies", "async-io"]
 
 [dependencies]
 atspi = { workspace = true, default-features = false, features = ["wrappers"] }
@@ -31,7 +31,7 @@ serde_plain.workspace = true
 enum_dispatch = "0.3.13"
 strum = { version = "0.27.1", features = ["derive"] }
 tokio = { workspace = true, optional = true }
-tracing = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true, features = ["attributes"] }
 ssip = { workspace = true, default-features = false, features = ["serde"] }
 xdg.workspace = true
 indextree = { version = "4.7.4", default-features = false }

--- a/common/src/cache.rs
+++ b/common/src/cache.rs
@@ -1,13 +1,16 @@
-use atspi::{EventProperties, ObjectRef};
+use atspi::EventProperties;
+#[cfg(feature = "zbus")]
+use atspi::ObjectRef;
+#[cfg(feature = "zbus")]
 use atspi_proxies::{accessible::AccessibleProxy, text::TextProxy};
 use serde::{Deserialize, Serialize};
-use zbus::{
-	names::OwnedUniqueName,
-	proxy::{Builder as ProxyBuilder, CacheProperties},
-	zvariant::{OwnedObjectPath, Type},
-};
+#[cfg(feature = "zbus")]
+use zbus::proxy::{Builder as ProxyBuilder, CacheProperties};
+use zbus_names::OwnedUniqueName;
+use zvariant::{ObjectPath, OwnedObjectPath, Type};
 
-use crate::{errors::AccessiblePrimitiveConversionError, ObjectPath};
+#[cfg(feature = "zbus")]
+use crate::errors::AccessiblePrimitiveConversionError;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, Type)]
 /// A struct which represents the bare minimum of an accessible for purposes of caching.
@@ -42,6 +45,7 @@ impl AccessiblePrimitive {
 	/// Convert into an [`atspi_proxies::accessible::AccessibleProxy`]. Must be async because the creation of an async proxy requires async itself.
 	/// # Errors
 	/// Will return a [`zbus::Error`] in the case of an invalid destination, path, or failure to create a `Proxy` from those properties.
+	#[cfg(feature = "zbus")]
 	#[cfg_attr(feature = "tracing", tracing::instrument(skip_all, level = "trace", ret, err))]
 	pub async fn into_accessible<'a>(
 		self,
@@ -60,6 +64,7 @@ impl AccessiblePrimitive {
 	/// Convert into an [`atspi_proxies::text::TextProxy`]. Must be async because the creation of an async proxy requires async itself.
 	/// # Errors
 	/// Will return a [`zbus::Error`] in the case of an invalid destination, path, or failure to create a `Proxy` from those properties.
+	#[cfg(feature = "zbus")]
 	#[cfg_attr(feature = "tracing", tracing::instrument(skip_all, level = "trace", ret, err))]
 	pub async fn into_text<'a>(self, conn: &zbus::Connection) -> zbus::Result<TextProxy<'a>> {
 		let id = self.id;
@@ -74,6 +79,7 @@ impl AccessiblePrimitive {
 	}
 }
 
+#[cfg(feature = "zbus")]
 impl From<ObjectRef> for AccessiblePrimitive {
 	fn from(atspi_accessible: ObjectRef) -> AccessiblePrimitive {
 		let tuple_converter = (atspi_accessible.name, atspi_accessible.path);
@@ -100,6 +106,7 @@ impl<'a> From<(String, ObjectPath<'a>)> for AccessiblePrimitive {
 		AccessiblePrimitive { id: so.1.to_string(), sender: so.0 }
 	}
 }
+#[cfg(feature = "zbus")]
 impl TryFrom<&AccessibleProxy<'_>> for AccessiblePrimitive {
 	type Error = AccessiblePrimitiveConversionError;
 
@@ -111,6 +118,7 @@ impl TryFrom<&AccessibleProxy<'_>> for AccessiblePrimitive {
 		Ok(AccessiblePrimitive { sender, id })
 	}
 }
+#[cfg(feature = "zbus")]
 impl TryFrom<AccessibleProxy<'_>> for AccessiblePrimitive {
 	type Error = AccessiblePrimitiveConversionError;
 

--- a/common/src/cache.rs
+++ b/common/src/cache.rs
@@ -1,8 +1,8 @@
+#[cfg(feature = "zbus")]
+use atspi::proxy::{accessible::AccessibleProxy, text::TextProxy};
 use atspi::EventProperties;
 #[cfg(feature = "zbus")]
 use atspi::ObjectRef;
-#[cfg(feature = "zbus")]
-use atspi_proxies::{accessible::AccessibleProxy, text::TextProxy};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "zbus")]
 use zbus::proxy::{Builder as ProxyBuilder, CacheProperties};

--- a/common/src/cache.rs
+++ b/common/src/cache.rs
@@ -41,7 +41,7 @@ impl AccessiblePrimitive {
 		Self { id, sender: sender.as_str().into() }
 	}
 
-	/// Convert into an [`atspi_proxies::accessible::AccessibleProxy`]. Must be async because the creation of an async proxy requires async itself.
+	/// Convert into an [`atspi::proxy::accessible::AccessibleProxy`]. Must be async because the creation of an async proxy requires async itself.
 	/// # Errors
 	/// Will return a [`zbus::Error`] in the case of an invalid destination, path, or failure to create a `Proxy` from those properties.
 	#[cfg_attr(feature = "tracing", tracing::instrument(skip_all, level = "trace", ret, err))]
@@ -59,7 +59,7 @@ impl AccessiblePrimitive {
 			.build()
 			.await
 	}
-	/// Convert into an [`atspi_proxies::text::TextProxy`]. Must be async because the creation of an async proxy requires async itself.
+	/// Convert into an [`atspi::proxy::text::TextProxy`]. Must be async because the creation of an async proxy requires async itself.
 	/// # Errors
 	/// Will return a [`zbus::Error`] in the case of an invalid destination, path, or failure to create a `Proxy` from those properties.
 	#[cfg_attr(feature = "tracing", tracing::instrument(skip_all, level = "trace", ret, err))]

--- a/common/src/cache.rs
+++ b/common/src/cache.rs
@@ -1,15 +1,14 @@
-#[cfg(feature = "zbus")]
-use atspi::proxy::{accessible::AccessibleProxy, text::TextProxy};
-use atspi::EventProperties;
-#[cfg(feature = "zbus")]
-use atspi::ObjectRef;
+use atspi::{
+	proxy::{accessible::AccessibleProxy, text::TextProxy},
+	EventProperties, ObjectRef,
+};
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "zbus")]
-use zbus::proxy::{Builder as ProxyBuilder, CacheProperties};
-use zbus_names::OwnedUniqueName;
-use zvariant::{ObjectPath, OwnedObjectPath, Type};
+use zbus::{
+	names::OwnedUniqueName,
+	proxy::{Builder as ProxyBuilder, CacheProperties},
+	zvariant::{ObjectPath, OwnedObjectPath, Type},
+};
 
-#[cfg(feature = "zbus")]
 use crate::errors::AccessiblePrimitiveConversionError;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, Type)]
@@ -45,7 +44,6 @@ impl AccessiblePrimitive {
 	/// Convert into an [`atspi_proxies::accessible::AccessibleProxy`]. Must be async because the creation of an async proxy requires async itself.
 	/// # Errors
 	/// Will return a [`zbus::Error`] in the case of an invalid destination, path, or failure to create a `Proxy` from those properties.
-	#[cfg(feature = "zbus")]
 	#[cfg_attr(feature = "tracing", tracing::instrument(skip_all, level = "trace", ret, err))]
 	pub async fn into_accessible<'a>(
 		self,
@@ -64,7 +62,6 @@ impl AccessiblePrimitive {
 	/// Convert into an [`atspi_proxies::text::TextProxy`]. Must be async because the creation of an async proxy requires async itself.
 	/// # Errors
 	/// Will return a [`zbus::Error`] in the case of an invalid destination, path, or failure to create a `Proxy` from those properties.
-	#[cfg(feature = "zbus")]
 	#[cfg_attr(feature = "tracing", tracing::instrument(skip_all, level = "trace", ret, err))]
 	pub async fn into_text<'a>(self, conn: &zbus::Connection) -> zbus::Result<TextProxy<'a>> {
 		let id = self.id;
@@ -79,7 +76,6 @@ impl AccessiblePrimitive {
 	}
 }
 
-#[cfg(feature = "zbus")]
 impl From<ObjectRef> for AccessiblePrimitive {
 	fn from(atspi_accessible: ObjectRef) -> AccessiblePrimitive {
 		let tuple_converter = (atspi_accessible.name, atspi_accessible.path);
@@ -106,7 +102,6 @@ impl<'a> From<(String, ObjectPath<'a>)> for AccessiblePrimitive {
 		AccessiblePrimitive { id: so.1.to_string(), sender: so.0 }
 	}
 }
-#[cfg(feature = "zbus")]
 impl TryFrom<&AccessibleProxy<'_>> for AccessiblePrimitive {
 	type Error = AccessiblePrimitiveConversionError;
 
@@ -118,7 +113,6 @@ impl TryFrom<&AccessibleProxy<'_>> for AccessiblePrimitive {
 		Ok(AccessiblePrimitive { sender, id })
 	}
 }
-#[cfg(feature = "zbus")]
 impl TryFrom<AccessibleProxy<'_>> for AccessiblePrimitive {
 	type Error = AccessiblePrimitiveConversionError;
 

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -24,6 +24,7 @@ pub enum OdiliaError {
 	Static(&'static str),
 	ServiceNotFound(String),
 	PredicateFailure(String),
+	Io(#[from] std::io::Error),
 }
 
 impl From<&'static str> for OdiliaError {

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -33,6 +33,11 @@ impl From<&'static str> for OdiliaError {
 		Self::Static(s)
 	}
 }
+impl From<String> for OdiliaError {
+	fn from(s: String) -> OdiliaError {
+		Self::Generic(s)
+	}
+}
 
 #[derive(Debug)]
 pub enum SendError {

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -1,7 +1,6 @@
 use std::{fmt, fmt::Debug, str::FromStr};
 
 use atspi::AtspiError;
-use atspi_common::AtspiError as AtspiTypesError;
 use serde_plain::Error as SerdePlainError;
 
 use crate::{cache::AccessiblePrimitive, command::OdiliaCommand};
@@ -9,13 +8,12 @@ use crate::{cache::AccessiblePrimitive, command::OdiliaCommand};
 #[derive(Debug, thiserror::Error)]
 pub enum OdiliaError {
 	AtspiError(AtspiError),
-	AtspiTypesError(AtspiTypesError),
 	PrimitiveConversionError(AccessiblePrimitiveConversionError),
 	NoAttributeError(String),
 	SerdeError(SerdePlainError),
-	Zbus(zbus::Error),
-	ZbusFdo(zbus::fdo::Error),
-	Zvariant(zbus::zvariant::Error),
+	Zbus(String),
+	ZbusFdo(String),
+	Zvariant(String),
 	SendError(SendError),
 	Cache(#[from] CacheError),
 	InfallibleConversion(#[from] std::convert::Infallible),
@@ -128,19 +126,22 @@ impl<T> From<std::sync::PoisonError<T>> for OdiliaError {
 		Self::PoisoningError
 	}
 }
+#[cfg(feature = "zbus")]
 impl From<zbus::fdo::Error> for OdiliaError {
 	fn from(spe: zbus::fdo::Error) -> Self {
-		Self::ZbusFdo(spe)
+		Self::ZbusFdo(format!("{spe:?}"))
 	}
 }
+#[cfg(feature = "zbus")]
 impl From<zbus::Error> for OdiliaError {
 	fn from(spe: zbus::Error) -> Self {
-		Self::Zbus(spe)
+		Self::Zbus(format!("{spe:?}"))
 	}
 }
+#[cfg(feature = "zbus")]
 impl From<zbus::zvariant::Error> for OdiliaError {
 	fn from(spe: zbus::zvariant::Error) -> Self {
-		Self::Zvariant(spe)
+		Self::Zvariant(format!("{spe:?}"))
 	}
 }
 impl From<SerdePlainError> for OdiliaError {

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -11,9 +11,9 @@ pub enum OdiliaError {
 	PrimitiveConversionError(AccessiblePrimitiveConversionError),
 	NoAttributeError(String),
 	SerdeError(SerdePlainError),
-	Zbus(String),
-	ZbusFdo(String),
-	Zvariant(String),
+	Zbus(#[from] zbus::Error),
+	ZbusFdo(#[from] zbus::fdo::Error),
+	Zvariant(#[from] zbus::zvariant::Error),
 	SendError(SendError),
 	Cache(#[from] CacheError),
 	InfallibleConversion(#[from] std::convert::Infallible),
@@ -25,6 +25,7 @@ pub enum OdiliaError {
 	ServiceNotFound(String),
 	PredicateFailure(String),
 	Io(#[from] std::io::Error),
+	Notify(#[from] NotifyError),
 }
 
 impl From<&'static str> for OdiliaError {
@@ -127,24 +128,6 @@ impl<T> From<std::sync::PoisonError<T>> for OdiliaError {
 		Self::PoisoningError
 	}
 }
-#[cfg(feature = "zbus")]
-impl From<zbus::fdo::Error> for OdiliaError {
-	fn from(spe: zbus::fdo::Error) -> Self {
-		Self::ZbusFdo(format!("{spe:?}"))
-	}
-}
-#[cfg(feature = "zbus")]
-impl From<zbus::Error> for OdiliaError {
-	fn from(spe: zbus::Error) -> Self {
-		Self::Zbus(format!("{spe:?}"))
-	}
-}
-#[cfg(feature = "zbus")]
-impl From<zbus::zvariant::Error> for OdiliaError {
-	fn from(spe: zbus::zvariant::Error) -> Self {
-		Self::Zvariant(format!("{spe:?}"))
-	}
-}
 impl From<SerdePlainError> for OdiliaError {
 	fn from(spe: SerdePlainError) -> Self {
 		Self::SerdeError(spe)
@@ -211,4 +194,12 @@ pub enum KeyFromStrError {
 pub enum ModeFromStrError {
 	#[error("Mode not found")]
 	ModeNameNotFound,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum NotifyError {
+	#[error("connection or monitor related error")]
+	Dbus(#[from] zbus::Error),
+	#[error("zbus specification defined error")]
+	DbusSpec(#[from] zbus::fdo::Error),
 }

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -26,6 +26,8 @@ pub enum OdiliaError {
 	PredicateFailure(String),
 	Io(#[from] std::io::Error),
 	Notify(#[from] NotifyError),
+	CommandLine(#[from] lexopt::Error),
+	Ssip(#[from] ssip_client_async::ClientError),
 }
 
 impl From<&'static str> for OdiliaError {

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -18,7 +18,7 @@ pub enum OdiliaError {
 	Cache(#[from] CacheError),
 	InfallibleConversion(#[from] std::convert::Infallible),
 	ConversionError(#[from] std::num::TryFromIntError),
-	Config(#[from] ConfigError),
+	Config(#[from] config::ConfigError),
 	PoisoningError,
 	Generic(String),
 	Static(&'static str),
@@ -84,14 +84,6 @@ send_err_impl!(tokio::sync::mpsc::error::SendError<ssip::Request>, SendError::Ss
 send_err_impl!(async_channel::SendError<atspi::Event>, SendError::Atspi, Box, "async-io");
 send_err_impl!(async_channel::SendError<OdiliaCommand>, SendError::Command, "async-io");
 send_err_impl!(async_channel::SendError<ssip::Request>, SendError::Ssip, "async-io");
-
-#[derive(Debug, thiserror::Error)]
-pub enum ConfigError {
-	#[error("Value not found in config file.")]
-	ValueNotFound,
-	#[error("The path for the config file was not found.")]
-	PathNotFound,
-}
 
 #[derive(Debug, thiserror::Error)]
 pub enum CacheError {

--- a/common/src/events.rs
+++ b/common/src/events.rs
@@ -1,4 +1,4 @@
-use atspi_common::Role;
+use atspi::Role;
 use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumDiscriminants};

--- a/common/src/from_state.rs
+++ b/common/src/from_state.rs
@@ -2,8 +2,8 @@
 
 use core::future::Future;
 
-use futures::{future::ErrInto, TryFutureExt};
 use futures_concurrency::future::TryJoin;
+use futures_util::future::{ErrInto, TryFutureExt};
 
 use crate::errors::OdiliaError;
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,7 +7,8 @@
 	unsafe_code
 )]
 
-use zbus::{names::UniqueName, zvariant::ObjectPath};
+use zbus_names::UniqueName;
+use zvariant::ObjectPath;
 
 pub mod cache;
 pub mod command;
@@ -21,5 +22,4 @@ pub mod settings;
 pub mod types;
 
 pub type Accessible = (UniqueName<'static>, ObjectPath<'static>);
-pub use atspi_common as atspi;
 pub use result::OdiliaResult as Result;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,8 +7,7 @@
 	unsafe_code
 )]
 
-use zbus_names::UniqueName;
-use zvariant::ObjectPath;
+use zbus::{names::UniqueName, zvariant::ObjectPath};
 
 pub mod cache;
 pub mod command;

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1,6 +1,6 @@
-use atspi_common::Granularity;
+use atspi::Granularity;
 use serde::{Deserialize, Serialize};
-use zbus::zvariant::OwnedObjectPath;
+use zvariant::OwnedObjectPath;
 
 pub type Accessible = (String, OwnedObjectPath);
 

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1,6 +1,6 @@
 use atspi::Granularity;
 use serde::{Deserialize, Serialize};
-use zvariant::OwnedObjectPath;
+use zbus::zvariant::OwnedObjectPath;
 
 pub type Accessible = (String, OwnedObjectPath);
 

--- a/input-server-keyboard/Cargo.toml
+++ b/input-server-keyboard/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["Accessibility"]
 [features]
 default = []
 proptest = []
+integration_tests = []
 
 [dependencies]
 atspi.workspace = true

--- a/input-server-keyboard/Cargo.toml
+++ b/input-server-keyboard/Cargo.toml
@@ -14,6 +14,7 @@ default = []
 proptest = []
 
 [dependencies]
+atspi.workspace = true
 nix.workspace = true
 odilia-common.workspace = true
 rdev = { version = "0.5.0", features = ["unstable_grab"], git = "https://github.com/TTWNO/rdev2/", branch = "odilia-keys-v2" }
@@ -21,7 +22,6 @@ serde_json.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-atspi-common.workspace = true
 proptest = "1.6.0"
 
 [[bin]]

--- a/input-server-keyboard/README.md
+++ b/input-server-keyboard/README.md
@@ -1,0 +1,18 @@
+# `odilia-input-server-keyboard`
+
+Control the Odilia screen reader with your keyboard.
+For security reasons, this is a separate process that communicates with Odilia via a Unix socket.
+
+## Running Tests
+
+When you run the tests for this crate, you can use `cargo test` to run the basic tests.
+
+For the `proptest`-based tests, enable the `proptest` feature flag.
+It is highly recommended to also enable `--release` mode, otherwise these tests take a _very_ long time to run.
+
+There are additional things you may want to set, like `PROPTEST_MAX_SHRINK_ITERS` (to get small reproducable examples).
+Here is what we use in our dev environment:
+
+```bash
+PROPTEST_MAX_SHRINK_ITERS=10000 PROPTEST_CASES=1000 cargo test --release --all-features
+```

--- a/input-server-keyboard/src/lib.rs
+++ b/input-server-keyboard/src/lib.rs
@@ -24,8 +24,8 @@ mod proptests;
 
 use std::{cmp::Ordering, sync::mpsc::SyncSender};
 
+use atspi::Role;
 use odilia_common::{
-	atspi::Role,
 	events::{
 		ChangeMode, Direction, Quit, ScreenReaderEvent as OdiliaEvent, StopSpeech,
 		StructuralNavigation,

--- a/input-server-keyboard/src/lib.rs
+++ b/input-server-keyboard/src/lib.rs
@@ -326,8 +326,8 @@ impl ComboSet {
 	/// ```
 	/// use rdev::Key;
 	/// use odilia_input_server_keyboard::{KeySet, ComboSet};
+	/// use atspi::Role;
 	/// use odilia_common::{
-	///   atspi::Role,
 	///   events::{ChangeMode, Direction, ScreenReaderEvent as OdiliaEvent, StopSpeech, StructuralNavigation},
 	///   modes::ScreenReaderMode as Mode,
 	/// };
@@ -479,8 +479,8 @@ impl ComboSets {
 	/// ```
 	/// use rdev::Key;
 	/// use odilia_input_server_keyboard::{KeySet, ComboSet, SetError, ComboSets};
+	/// use atspi::Role;
 	/// use odilia_common::{
-	///   atspi::Role,
 	///   events::{ChangeMode, Direction, ScreenReaderEvent as OdiliaEvent, StopSpeech, StructuralNavigation},
 	///   modes::ScreenReaderMode as Mode,
 	/// };

--- a/input-server-keyboard/src/proptests.rs
+++ b/input-server-keyboard/src/proptests.rs
@@ -3,7 +3,7 @@ use std::{
 	time::SystemTime,
 };
 
-use atspi_common::Role;
+use atspi::Role;
 use odilia_common::events::*;
 use proptest::prelude::*;
 use rdev::{Button, Event, EventType, Key};

--- a/input-server-keyboard/tests/test_key_capture.rs
+++ b/input-server-keyboard/tests/test_key_capture.rs
@@ -18,7 +18,7 @@ const SEQUENCE_OF_KEYS: [&str; 5] = ["key", "58:1", "34:1", "34:0", "58:0"];
 
 fn handle_events_to_socket(rx: Receiver<OdiliaEvent>) {
 	assert_eq!(
-		rx.recv(),
+		rx.recv_timeout(Duration::from_secs(1)),
 		Ok(StopSpeech.into()),
 		"The even generated from the keyboard state is not the expected one!"
 	);

--- a/input-server-keyboard/tests/test_key_capture.rs
+++ b/input-server-keyboard/tests/test_key_capture.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration_tests")]
+
 use std::{
 	process::Command,
 	sync::mpsc::{sync_channel, Receiver},

--- a/input-server-keyboard/tests/test_key_capture.rs
+++ b/input-server-keyboard/tests/test_key_capture.rs
@@ -14,6 +14,13 @@ use odilia_common::{
 use odilia_input_server_keyboard::{callback, ComboSets, State};
 use rdev::grab;
 
+/// Arguments to [`ydotool`]:
+///
+/// 1. "key": press keys by keycode
+/// 2. press capslock
+/// 3. press g
+/// 4. release g
+/// 5. release capslock
 const SEQUENCE_OF_KEYS: [&str; 5] = ["key", "58:1", "34:1", "34:0", "58:0"];
 
 fn handle_events_to_socket(rx: Receiver<OdiliaEvent>) {

--- a/input-server-keyboard/tests/test_key_capture.rs
+++ b/input-server-keyboard/tests/test_key_capture.rs
@@ -27,7 +27,7 @@ fn handle_events_to_socket(rx: Receiver<OdiliaEvent>) {
 	assert_eq!(
 		rx.recv_timeout(Duration::from_secs(1)),
 		Ok(StopSpeech.into()),
-		"The even generated from the keyboard state is not the expected one!"
+		"unexpected event recieved from the keyboard state machine, this is a bug (or your setup is misconfigured)"
 	);
 }
 

--- a/input-server-keyboard/tests/test_key_capture.rs
+++ b/input-server-keyboard/tests/test_key_capture.rs
@@ -1,0 +1,50 @@
+use std::{
+	process::Command,
+	sync::mpsc::{sync_channel, Receiver},
+	thread,
+	time::Duration,
+};
+
+use odilia_common::{
+	events::{ScreenReaderEvent as OdiliaEvent, StopSpeech},
+	modes::ScreenReaderMode as Mode,
+};
+use odilia_input_server_keyboard::{callback, ComboSets, State};
+use rdev::grab;
+
+const SEQUENCE_OF_KEYS: [&str; 5] = ["key", "58:1", "34:1", "34:0", "58:0"];
+
+fn handle_events_to_socket(rx: Receiver<OdiliaEvent>) {
+	assert_eq!(
+		rx.recv(),
+		Ok(StopSpeech.into()),
+		"The even generated from the keyboard state is not the expected one!"
+	);
+}
+
+#[test]
+fn test_key_capture() {
+	let (ev_tx, ev_rx) = sync_channel::<OdiliaEvent>(5);
+	let combos = ComboSets::default();
+	let state = State {
+		mode: Mode::Focus,
+		activation_key_pressed: false,
+		// no allocations below 10-key rollover
+		pressed: Vec::with_capacity(10),
+		combos,
+		tx: ev_tx,
+	};
+	let _ = thread::spawn(move || {
+		// This will block.
+		if let Err(error) = grab(callback, state) {
+			tracing::error!("Error grabbing keyboard: {error:?}");
+		}
+	});
+	thread::sleep(Duration::from_millis(500));
+	let _cmd = Command::new("ydotool")
+		.args(SEQUENCE_OF_KEYS)
+		.output()
+		.expect("Unable to find `ydotool`");
+
+	handle_events_to_socket(ev_rx);
+}

--- a/input/Cargo.toml
+++ b/input/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2021"
 async-channel.workspace = true
 async-fs.workspace = true
 async-net.workspace = true
+async-stream = "0.3.6"
 futures-lite.workspace = true
 futures-util = { workspace = true, features = ["alloc"] }
 nix.workspace = true

--- a/input/Cargo.toml
+++ b/input/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2021"
 
 [dependencies]
 async-channel = { version = "2.3.1", default-features = false }
+async-fs = "2.1.2"
+async-io = "2.4.1"
+async-net = "2.0.0"
 futures.workspace = true
 futures-lite = "2.6.0"
 nix.workspace = true

--- a/input/Cargo.toml
+++ b/input/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2021"
 [dependencies]
 async-channel = { version = "2.3.1", default-features = false }
 async-fs = "2.1.2"
-async-io = "2.4.1"
 async-net = "2.0.0"
 futures.workspace = true
 futures-lite = "2.6.0"
@@ -23,5 +22,4 @@ odilia-common.workspace = true
 serde_json.workspace = true
 smol-cancellation-token.workspace = true
 sysinfo = { version = "0.26.8", default-features = false }
-tokio.workspace = true
 tracing.workspace = true

--- a/input/Cargo.toml
+++ b/input/Cargo.toml
@@ -12,14 +12,14 @@ categories = ["accessibility"]
 edition = "2021"
 
 [dependencies]
-async-channel = { version = "2.3.1", default-features = false }
-async-fs = "2.1.2"
-async-net = "2.0.0"
-futures.workspace = true
-futures-lite = "2.6.0"
+async-channel.workspace = true
+async-fs.workspace = true
+async-net.workspace = true
+futures-lite.workspace = true
+futures-util.workspace = true
 nix.workspace = true
 odilia-common.workspace = true
 serde_json.workspace = true
 smol-cancellation-token.workspace = true
 sysinfo = { version = "0.26.8", default-features = false }
-tracing.workspace = true
+tracing = { workspace = true, features = ["attributes"] }

--- a/input/Cargo.toml
+++ b/input/Cargo.toml
@@ -16,7 +16,7 @@ async-channel.workspace = true
 async-fs.workspace = true
 async-net.workspace = true
 futures-lite.workspace = true
-futures-util.workspace = true
+futures-util = { workspace = true, features = ["alloc"] }
 nix.workspace = true
 odilia-common.workspace = true
 serde_json.workspace = true

--- a/input/Cargo.toml
+++ b/input/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odilia-input"
-version = "0.0.3"
+version = "0.3.0"
 authors = ["Michael Connor Buchan <mikey@blindcomputing.org>", "Tait Hoyem <tait@tait.tech>", "Alberto Tirla <albertotirla@gmail.com>"]
 description = "Input subsystem for the Odilia screen reader."
 license = "MIT OR Apache-2.0"

--- a/input/Cargo.toml
+++ b/input/Cargo.toml
@@ -13,6 +13,8 @@ edition = "2021"
 
 [dependencies]
 async-channel = { version = "2.3.1", default-features = false }
+futures.workspace = true
+futures-lite = "2.6.0"
 nix.workspace = true
 odilia-common.workspace = true
 serde_json.workspace = true

--- a/input/src/lib.rs
+++ b/input/src/lib.rs
@@ -183,7 +183,6 @@ pub fn sr_event_receiver(
 					Ok((socket, address)) => {
 						tracing::debug!("Ok from socket");
 						return Some((
-							empty,
 							handle_event(
 								socket,
 								address,
@@ -191,6 +190,7 @@ pub fn sr_event_receiver(
 								shutdown.clone(),
 							)
 							.boxed(),
+							empty,
 						));
 					}
 					Err(e) => {

--- a/input/src/lib.rs
+++ b/input/src/lib.rs
@@ -30,7 +30,7 @@ use futures_lite::{
 };
 use futures_util::{future::BoxFuture, FutureExt};
 use nix::unistd::Uid;
-use odilia_common::events::ScreenReaderEvent;
+use odilia_common::{errors::OdiliaError, events::ScreenReaderEvent};
 use smol_cancellation_token::CancellationToken;
 use sysinfo::{ProcessExt, System, SystemExt};
 
@@ -75,8 +75,7 @@ fn get_log_file_name() -> String {
 /// # Errors
 /// - This function will return an error type if the same function is already running. This is checked by looking for a file on disk. If the file exists, this program is probably already running.
 /// - If there is no way to get access to the directory.
-pub async fn setup_input_server() -> Result<UnixListener, Box<dyn std::error::Error + Send + Sync>>
-{
+pub async fn setup_input_server() -> Result<UnixListener, OdiliaError> {
 	let (pid_file_path, sock_file_path) = get_file_paths();
 	let log_file_name = get_log_file_name();
 

--- a/input/src/lib.rs
+++ b/input/src/lib.rs
@@ -151,10 +151,9 @@ pub async fn setup_input_server() -> Result<UnixListener, OdiliaError> {
 ///     .expect("Valid listener");
 /// let (sender, _receiver) = bounded(128);
 /// let ct = CancellationToken::new();
-/// let stream = sr_event_receiver(listener, sender, ct);
-/// for fut in stream.iter() {
-///     spawn(fut);
-/// }
+/// // For tokio; for async-io based executors, remember to call .detach()
+/// let stream = sr_event_receiver(listener, sender, ct)
+///     .for_each(|fut| spawn(fut));
 /// ```
 ///
 /// If the cancellation token is triggered, this stream will finish.

--- a/input/src/lib.rs
+++ b/input/src/lib.rs
@@ -12,16 +12,6 @@
 
 mod proxy;
 
-use async_channel::Sender;
-use async_fs as fs;
-use async_net::unix::{UnixListener, UnixStream};
-use futures::future::FutureExt;
-use futures_lite::future::{self, FutureExt as LiteExt};
-use futures_lite::prelude::*;
-use futures_lite::stream;
-use nix::unistd::Uid;
-use odilia_common::events::ScreenReaderEvent;
-use smol_cancellation_token::CancellationToken;
 use std::{
 	env,
 	os::unix::net::SocketAddr,
@@ -30,9 +20,18 @@ use std::{
 	time::{SystemTime, UNIX_EPOCH},
 };
 
-use eyre::{Context, Report};
+use async_channel::Sender;
+use async_fs as fs;
+use async_net::unix::{UnixListener, UnixStream};
+use futures::future::FutureExt;
+use futures_lite::{
+	future::{self, FutureExt as LiteExt},
+	prelude::*,
+	stream,
+};
 use nix::unistd::Uid;
 use odilia_common::events::ScreenReaderEvent;
+use smol_cancellation_token::CancellationToken;
 use sysinfo::{ProcessExt, System, SystemExt};
 
 async fn or_cancel<F>(f: F, token: &CancellationToken) -> Result<F::Output, std::io::Error>

--- a/input/src/lib.rs
+++ b/input/src/lib.rs
@@ -188,7 +188,6 @@ pub fn sr_event_receiver(
 					}
 					Err(e) => {
 						tracing::error!("accept function failed: {:?}", e);
-						continue;
 					}
 				}
 			}

--- a/input/src/lib.rs
+++ b/input/src/lib.rs
@@ -144,9 +144,19 @@ pub async fn setup_input_server() -> Result<UnixListener, Box<dyn std::error::Er
 /// Noramlly, the best way to do this is like so:
 ///
 /// ```rust,no_run
-/// use futures_lite::stream::StreamExt;
-/// let stream = sr_event_receiver(UnixListener, Sender<ScreenReaderEvent>, CancellationToken);
-/// stream.for_each(|fut| { tokio::spawn(fut); });
+/// # use futures_lite::stream::StreamExt;
+/// # use smol_cancellation_token::CancellationToken;
+/// # use async_channel::bounded;
+/// # use async_net::unix::UnixListener;
+/// use odilia_input::sr_event_receiver;
+/// // use smol::spawn or tokio::spawn
+/// # fn spawn<F>(_f: F) {}
+/// let listener = UnixListener::bind("/some/path/here")
+///     .expect("Valid listener!");
+/// let (sender, _receiver) = bounded(128);
+/// let ct = CancellationToken::new();
+/// let stream = sr_event_receiver(listener, sender, ct);
+/// stream.for_each(|fut| { spawn(fut); });
 /// ```
 ///
 /// If the cancellation token is trigged, this stream will finish.

--- a/odilia-notify/Cargo.toml
+++ b/odilia-notify/Cargo.toml
@@ -17,9 +17,9 @@ futures.workspace=true
 itertools = "0.14.0"
 serde.workspace=true
 thiserror.workspace = true
-tokio.workspace=true
 tracing.workspace=true
 zbus.workspace=true
 [dev-dependencies]
 notify-rust = "4.10.0"
 tracing-subscriber = { workspace = true, features = ["fmt"] }
+tokio = { workspace=true, features = ["time"] }

--- a/odilia-notify/Cargo.toml
+++ b/odilia-notify/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-futures.workspace=true
+futures-lite.workspace=true
 itertools = "0.14.0"
 serde.workspace=true
 thiserror.workspace = true

--- a/odilia-notify/Cargo.toml
+++ b/odilia-notify/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2021"
 
 [dependencies]
 futures-lite.workspace=true
-itertools = "0.14.0"
 serde.workspace=true
 thiserror.workspace = true
 tracing.workspace=true

--- a/odilia-notify/Cargo.toml
+++ b/odilia-notify/Cargo.toml
@@ -19,6 +19,7 @@ serde.workspace=true
 thiserror.workspace = true
 tracing.workspace=true
 zbus.workspace=true
+odilia-common.workspace=true
 [dev-dependencies]
 notify-rust = "4.10.0"
 tracing-subscriber = { workspace = true, features = ["fmt"] }

--- a/odilia-notify/src/error.rs
+++ b/odilia-notify/src/error.rs
@@ -1,9 +1,0 @@
-use thiserror::Error;
-
-#[derive(Error, Debug)]
-pub enum NotifyError {
-	#[error("connection or monitor related error")]
-	Dbus(#[from] zbus::Error),
-	#[error("zbus specification defined error")]
-	DbusSpec(#[from] zbus::fdo::Error),
-}

--- a/odilia-notify/src/lib.rs
+++ b/odilia-notify/src/lib.rs
@@ -7,8 +7,8 @@ mod action;
 mod notification;
 mod urgency;
 use notification::Notification;
-mod error;
-use error::NotifyError;
+use odilia_common::errors::NotifyError;
+
 #[instrument]
 pub async fn listen_to_dbus_notifications() -> Result<impl Stream<Item = Notification>, NotifyError>
 {

--- a/odilia-notify/src/lib.rs
+++ b/odilia-notify/src/lib.rs
@@ -1,4 +1,4 @@
-use futures::{Stream, StreamExt};
+use futures_lite::{Stream, StreamExt};
 use tracing::{debug, info, instrument};
 use zbus::{
 	fdo::MonitoringProxy, message::Type as MessageType, Connection, MatchRule, MessageStream,
@@ -33,11 +33,11 @@ pub async fn listen_to_dbus_notifications() -> Result<impl Stream<Item = Notific
 	info!("listening for notifications");
 	monitor.become_monitor(&[notify_rule], 0).await?;
 
-	let stream = MessageStream::from(connection).filter_map(move |message| async {
+	let stream = MessageStream::from(connection).filter_map(move |message| {
 		let notification = message.ok()?.try_into().ok()?;
 		debug!(?notification, "adding notification to stream");
 		Some(notification)
 	});
 	//pinn the stream on the heap, because it's otherwise unusable. Warning: this inccurs additional memory allocations and is not exactly pretty, so alternative solutions should be found
-	Ok(Box::pin(stream))
+	Ok(stream)
 }

--- a/odilia-notify/src/notification.rs
+++ b/odilia-notify/src/notification.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use zbus::{zvariant::Value, Message};
 
@@ -25,9 +24,12 @@ impl TryFrom<Message> for Notification {
 		let body = msg.body();
 		let mb: MessageBody = body.deserialize()?;
 		let (app_name, _, _, title, body, actions, mut options, _) = mb;
-		let actions = actions
-			.iter()
-			.tuples()
+		// even elements
+		let names = actions.iter().step_by(2);
+		// odd elements
+		let methods = actions.iter().skip(1).step_by(2);
+		let actions = names
+			.zip(methods)
 			.map(|(name, method)| Action {
 				name: name.to_string(),
 				method: method.to_string(),

--- a/odilia-notify/tests/receive_notifications.rs
+++ b/odilia-notify/tests/receive_notifications.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, time::Duration};
 
-use futures::StreamExt;
+use futures_lite::StreamExt;
 use notify_rust::Notification;
 use odilia_notify::listen_to_dbus_notifications;
 

--- a/odilia-tower/Cargo.toml
+++ b/odilia-tower/Cargo.toml
@@ -10,11 +10,11 @@ keywords = ["accessibility", "tower"]
 readme = "README.md"
 
 [dependencies]
-futures.workspace = true
-odilia-common.workspace = true
-pin-project.workspace = true 
+futures-util.workspace = true
+odilia-common = { workspace = true, default-features = false }
+pin-project-lite.workspace = true 
 static_assertions = "1.1.0"
-tower.workspace = true
+tower = { workspace = true, features = ["util"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/odilia-tower/Cargo.toml
+++ b/odilia-tower/Cargo.toml
@@ -18,5 +18,6 @@ tower = { workspace = true, features = ["util"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-futures = { workspace = true, features = ["executor"] }
+async-io.workspace = true
 ssip.workspace = true
+futures-lite.workspace = true

--- a/odilia-tower/Cargo.toml
+++ b/odilia-tower/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 futures-util.workspace = true
-odilia-common = { workspace = true, default-features = false }
+odilia-common.workspace = true
 pin-project-lite.workspace = true 
 static_assertions = "1.1.0"
 tower = { workspace = true, features = ["util"] }

--- a/odilia-tower/src/async_try.rs
+++ b/odilia-tower/src/async_try.rs
@@ -11,7 +11,7 @@ use core::{
 	task::{Context, Poll},
 };
 
-use futures::TryFutureExt;
+use futures_util::TryFutureExt;
 #[allow(clippy::module_name_repetitions)]
 use odilia_common::from_state::TryFromState;
 use static_assertions::const_assert_eq;
@@ -145,17 +145,18 @@ where
 
 use core::pin::Pin;
 
-use futures::future::{err, Either, ErrInto, Flatten, FutureExt, Ready};
+use futures_util::future::{err, Either, ErrInto, Flatten, FutureExt, Ready};
 use tower::{util::Oneshot, ServiceExt};
 
+pin_project_lite::pin_project! {
 /// A version of [`tower::util::future::AndThenFuture`] that is not generic over an un-namable
 /// future type.
-#[pin_project::pin_project]
-pub struct AndThenCall<F, S, O, E> {
-	#[pin]
-	fut: F,
-	svc: S,
-	_marker: PhantomData<(E, O)>,
+    pub struct AndThenCall<F, S, O, E> {
+      #[pin]
+      fut: F,
+      svc: S,
+      _marker: PhantomData<(E, O)>,
+    }
 }
 impl<F, S, O, E> Future for AndThenCall<F, S, O, E>
 where

--- a/odilia-tower/src/service_ext.rs
+++ b/odilia-tower/src/service_ext.rs
@@ -16,7 +16,7 @@ pub trait ServiceExt<Request>: Service<Request> {
 	/// use assert_matches::assert_matches;
 	/// use odilia_tower::service_ext::ServiceExt;
 	/// use tower::{service_fn, Service};
-	/// use futures::executor::block_on;
+	/// use async_io::block_on;
 	/// use std::num::TryFromIntError;
 	/// // NOTE: the associated error type must implement From<E>, where E is the error in converting
 	/// // from the new input type (in this example, u64) to the inner one (u8).
@@ -58,10 +58,8 @@ pub trait ServiceExt<Request>: Service<Request> {
 	///   async_try::AsyncTryFrom,
 	/// };
 	/// use tower::{service_fn, Service};
-	/// use futures::{
-	///   executor::block_on,
-	///   future::{ready, Ready},
-	/// };
+	/// use async_io::block_on;
+	/// use core::future::{ready, Ready};
 	/// use std::num::TryFromIntError;
 	/// // Used to get around "foreign traits on foreign types" rule.
 	/// #[derive(Debug, PartialEq, Eq)]
@@ -129,7 +127,7 @@ pub trait ServiceExt<Request>: Service<Request> {
 	/// ```
 	/// use odilia_tower::service_ext::ServiceExt;
 	/// use tower::{service_fn, Service};
-	/// use futures::executor::block_on;
+	/// use async_io::block_on;
 	/// use std::{convert::Infallible, sync::Arc};
 	/// // a stand in for some comlpex type, don't actually do this.
 	/// type State = Arc<usize>;

--- a/odilia-tower/src/sync_try.rs
+++ b/odilia-tower/src/sync_try.rs
@@ -7,7 +7,7 @@ use core::{
 	task::{Context, Poll},
 };
 
-use futures::future::{err, Either, Ready};
+use futures_util::future::{err, Either, Ready};
 use static_assertions::const_assert_eq;
 use tower::{Layer, Service};
 

--- a/odilia-tower/src/unwrap_svc.rs
+++ b/odilia-tower/src/unwrap_svc.rs
@@ -193,7 +193,7 @@ where
 pub trait UnwrapFutExt: Future {
 	///
 	/// ```
-	/// use futures::executor::block_on;
+	/// use async_io::block_on;
 	/// use std::convert::Infallible;
 	/// use odilia_tower::unwrap_svc::UnwrapFutExt;
 	/// async fn first_four_bits(x: u8) -> Result<u8, Infallible> {
@@ -211,8 +211,8 @@ pub trait UnwrapFutExt: Future {
 		UnwrapFut { fut: self, _marker: PhantomData }
 	}
 	/// ```
-	/// use futures::executor::block_on;
-	/// use futures::future::TryFutureExt;
+	/// use async_io::block_on;
+	/// use futures_util::TryFutureExt;
 	/// use odilia_tower::unwrap_svc::UnwrapFutExt;
 	/// use std::convert::Infallible;
 	/// #[derive(Debug, PartialEq)]
@@ -237,13 +237,13 @@ pub trait UnwrapFutExt: Future {
 	}
 	/// Map's a future into it's corresponding [`TryIntoCommands::try_into_commands`] output.
 	/// This type is only for being able to name it.
-	/// The same effect can be achieved with [`futures::future::FutureExt::map`] if you do not need to name the type.
+	/// The same effect can be achieved with [`futures_util::FutureExt::map`] if you do not need to name the type.
 	///
 	/// ```
 	/// use ssip::Priority;
 	/// use odilia_common::command::{OdiliaCommand, Speak, TryIntoCommands};
-	/// use futures::executor::block_on;
-	/// use futures::future::TryFutureExt;
+	/// use async_io::block_on;
+	/// use futures_util::TryFutureExt;
 	/// use odilia_tower::unwrap_svc::{UnwrapFutExt, TryIntoCommandFut};
 	/// use std::convert::Infallible;
 	/// async fn commands() -> (Priority, &'static str) {

--- a/odilia-tower/src/unwrap_svc.rs
+++ b/odilia-tower/src/unwrap_svc.rs
@@ -13,7 +13,7 @@ use core::{
 	task::{Context, Poll},
 };
 
-use futures::{future::OkInto, TryFutureExt};
+use futures_util::{future::OkInto, TryFutureExt};
 use odilia_common::command::TryIntoCommands;
 use tower::Service;
 
@@ -114,12 +114,13 @@ where
 
 use core::pin::Pin;
 
-/// Map a future result into return of [`TryIntoCommands::try_into_commands`].
-#[pin_project::pin_project]
-pub struct TryIntoCommandFut<F, Ic, E> {
-	#[pin]
-	f: F,
-	_marker: PhantomData<(Ic, E)>,
+pin_project_lite::pin_project! {
+    /// Map a future result into return of [`TryIntoCommands::try_into_commands`].
+    pub struct TryIntoCommandFut<F, Ic, E> {
+      #[pin]
+      f: F,
+      _marker: PhantomData<(Ic, E)>,
+    }
 }
 impl<F, Ic, E> Future for TryIntoCommandFut<F, Ic, E>
 where
@@ -136,13 +137,14 @@ where
 	}
 }
 
+pin_project_lite::pin_project! {
 /// A future which flattens a future's nested results when the outer result in
 /// [`std::convert::Infallible`].
-#[pin_project::pin_project]
-pub struct FlattenFutResult<F, O, E1> {
-	#[pin]
-	fut: F,
-	_marker: PhantomData<(O, E1)>,
+    pub struct FlattenFutResult<F, O, E1> {
+      #[pin]
+      fut: F,
+      _marker: PhantomData<(O, E1)>,
+    }
 }
 impl<F, O, E1> Future for FlattenFutResult<F, O, E1>
 where
@@ -158,18 +160,19 @@ where
 	}
 }
 
-/// A future which unwraps the future's [`Future::Output`] value if it is a [`Result<T,
-/// Infallible>`] and converts it into `T`.
-///
-/// This is useful in the context of [`tower`] where all services must return `Result<T, E>`, even
-/// if `Err(E)` will never occur.
-/// To ensure safety, this is only possible to use when the `E` parameter is
-/// [`std::convert::Infallible`].
-#[pin_project::pin_project]
-pub struct UnwrapFut<F, O, E> {
-	#[pin]
-	fut: F,
-	_marker: PhantomData<(O, E)>,
+pin_project_lite::pin_project! {
+    /// A future which unwraps the future's [`Future::Output`] value if it is a [`Result<T,
+    /// Infallible>`] and converts it into `T`.
+    ///
+    /// This is useful in the context of [`tower`] where all services must return `Result<T, E>`, even
+    /// if `Err(E)` will never occur.
+    /// To ensure safety, this is only possible to use when the `E` parameter is
+    /// [`std::convert::Infallible`].
+    pub struct UnwrapFut<F, O, E> {
+      #[pin]
+      fut: F,
+      _marker: PhantomData<(O, E)>,
+    }
 }
 impl<F, O, Infallible> Future for UnwrapFut<F, O, Infallible>
 where

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -50,7 +50,6 @@ tracing.workspace = true
 xdg.workspace=true
 zbus.workspace = true
 odilia-notify = { version = "0.1.0", path = "../odilia-notify" }
-tokio-util.workspace=true
 tracing-journald = "0.3.0"
 ssip.workspace = true
 pin-project.workspace = true
@@ -63,7 +62,7 @@ config = { version = "0.15.11", default-features = false, features = ["toml"] }
 lexopt = { version = "0.3.1", default-features = false }
 smol-cancellation-token.workspace = true
 async-signal = "0.2.11"
-async-io = "2.4.1"
+async-io.workspace = true
 futures-lite = { version = "2.6.0", default-features = false }
 async-channel = { version = "2.3.1", default-features = false }
 futures-concurrency.workspace = true
@@ -71,7 +70,6 @@ futures-util.workspace = true
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-tokio-test = "0.4.2"
 
 [features]
 tokio-console = ["dep:console-subscriber", "tracing-subscriber/env-filter"]

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -41,7 +41,6 @@ odilia-input = { path = "../input", version = "0.3.0" }
 odilia-tts = { path = "../tts", version = "0.1.4" }
 odilia-tower = { path = "../odilia-tower/", version = "0.1.0" }
 ssip-client-async.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread"] }
 tower.workspace = true
 tracing-error.workspace = true
 tracing-subscriber.workspace = true
@@ -53,25 +52,15 @@ odilia-notify = { version = "0.1.0", path = "../odilia-notify" }
 tracing-journald = "0.3.0"
 ssip.workspace = true
 pin-project.workspace = true
-console-subscriber = { version = "0.4.0", optional = true }
 refinement = "0.5.0"
 derived-deref = "2.1.0"
 tower-iter = { version = "0.1", path = "../tower-iter/" }
-which = "7.0.2"
 config = { version = "0.15.11", default-features = false, features = ["toml"] }
 lexopt = { version = "0.3.1", default-features = false }
 smol-cancellation-token.workspace = true
 async-signal = "0.2.11"
-async-io.workspace = true
 futures-lite = { version = "2.6.0", default-features = false }
 async-channel = { version = "2.3.1", default-features = false }
 futures-concurrency.workspace = true
 futures-util.workspace = true
-smol = "2.0.2"
 async-executor = { version = "1.13.2", features = ["static"] }
-
-[dev-dependencies]
-lazy_static = "1.4.0"
-
-[features]
-tokio-console = ["dep:console-subscriber", "tracing-subscriber/env-filter"]

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -67,6 +67,8 @@ futures-lite = { version = "2.6.0", default-features = false }
 async-channel = { version = "2.3.1", default-features = false }
 futures-concurrency.workspace = true
 futures-util.workspace = true
+smol = "2.0.2"
+async-executor = { version = "1.13.2", features = ["static"] }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -33,7 +33,7 @@ pre-release-replacements = [
 atspi.workspace = true
 atspi-proxies.workspace = true
 atspi-common.workspace = true
-atspi-connection.workspace = true
+atspi-connection = {workspace = true, features = ["wrappers"] }
 circular-queue = "^0.2.6"
 futures.workspace = true
 odilia-common.workspace = true

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -54,7 +54,7 @@ ssip.workspace = true
 refinement = "0.5.0"
 derived-deref = "2.1.0"
 tower-iter = { version = "0.1", path = "../tower-iter/" }
-config = { version = "0.15.11", default-features = false, features = ["toml"] }
+config.workspace = true
 lexopt = { version = "0.3.1", default-features = false }
 smol-cancellation-token.workspace = true
 async-signal = "0.2.11"

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -52,7 +52,6 @@ xdg.workspace=true
 zbus.workspace = true
 odilia-notify = { version = "0.1.0", path = "../odilia-notify" }
 tokio-util.workspace=true
-toml = "0.8.11"
 tracing-journald = "0.3.0"
 ssip.workspace = true
 pin-project.workspace = true

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -31,9 +31,6 @@ pre-release-replacements = [
 
 [dependencies]
 atspi.workspace = true
-atspi-proxies.workspace = true
-atspi-common.workspace = true
-atspi-connection = {workspace = true, features = ["wrappers"] }
 circular-queue = "^0.2.6"
 odilia-common.workspace = true
 odilia-cache.workspace = true

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -35,7 +35,6 @@ atspi-proxies.workspace = true
 atspi-common.workspace = true
 atspi-connection = {workspace = true, features = ["wrappers"] }
 circular-queue = "^0.2.6"
-futures.workspace = true
 odilia-common.workspace = true
 odilia-cache.workspace = true
 odilia-input = { path = "../input", version = "0.3.0" }
@@ -68,6 +67,7 @@ async-io = "2.4.1"
 futures-lite = { version = "2.6.0", default-features = false }
 async-channel = { version = "2.3.1", default-features = false }
 futures-concurrency.workspace = true
+futures-util.workspace = true
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -51,7 +51,6 @@ zbus.workspace = true
 odilia-notify = { version = "0.1.0", path = "../odilia-notify" }
 tracing-journald = "0.3.0"
 ssip.workspace = true
-pin-project.workspace = true
 refinement = "0.5.0"
 derived-deref = "2.1.0"
 tower-iter = { version = "0.1", path = "../tower-iter/" }
@@ -59,8 +58,9 @@ config = { version = "0.15.11", default-features = false, features = ["toml"] }
 lexopt = { version = "0.3.1", default-features = false }
 smol-cancellation-token.workspace = true
 async-signal = "0.2.11"
-futures-lite = { version = "2.6.0", default-features = false }
+futures-lite.workspace = true
 async-channel = { version = "2.3.1", default-features = false }
 futures-concurrency.workspace = true
 futures-util.workspace = true
 async-executor = { version = "1.13.2", features = ["static"] }
+pin-project-lite.workspace = true

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -55,8 +55,8 @@ refinement = "0.5.0"
 derived-deref = "2.1.0"
 tower-iter = { version = "0.1", path = "../tower-iter/" }
 config.workspace = true
-lexopt = { version = "0.3.1", default-features = false }
 smol-cancellation-token.workspace = true
+lexopt.workspace = true
 async-signal = "0.2.11"
 futures-lite.workspace = true
 async-channel = { version = "2.3.1", default-features = false }

--- a/odilia/Cargo.toml
+++ b/odilia/Cargo.toml
@@ -38,7 +38,7 @@ circular-queue = "^0.2.6"
 futures.workspace = true
 odilia-common.workspace = true
 odilia-cache.workspace = true
-odilia-input = { path = "../input", version = "0.0.3" }
+odilia-input = { path = "../input", version = "0.3.0" }
 odilia-tts = { path = "../tts", version = "0.1.4" }
 odilia-tower = { path = "../odilia-tower/", version = "0.1.0" }
 ssip-client-async.workspace = true

--- a/odilia/src/logging.rs
+++ b/odilia/src/logging.rs
@@ -8,9 +8,9 @@ use std::io;
 use odilia_common::settings::{log::LoggingKind, ApplicationConfig};
 use tracing_error::ErrorLayer;
 use tracing_subscriber::prelude::*;
-use tracing_tree::{time::Uptime, HierarchicalLayer};
 #[cfg(feature = "tokio-console")]
 use tracing_subscriber::EnvFilter;
+use tracing_tree::{time::Uptime, HierarchicalLayer};
 
 /// Initialise the logging stack
 /// this requires an application configuration structure, so configuration must be initialized before logging is

--- a/odilia/src/logging.rs
+++ b/odilia/src/logging.rs
@@ -8,8 +8,6 @@ use std::io;
 use odilia_common::settings::{log::LoggingKind, ApplicationConfig};
 use tracing_error::ErrorLayer;
 use tracing_subscriber::prelude::*;
-#[cfg(feature = "tokio-console")]
-use tracing_subscriber::EnvFilter;
 use tracing_tree::{time::Uptime, HierarchicalLayer};
 
 /// Initialise the logging stack
@@ -36,14 +34,6 @@ pub fn init(config: &ApplicationConfig) -> Result<(), Box<dyn std::error::Error 
 			.with_syslog_identifier("odilia".to_owned())
 			.boxed(),
 	};
-	#[cfg(feature = "tokio-console")]
-	let trace_sub = {
-		let console_layer = console_subscriber::spawn();
-		tracing_subscriber::Registry::default()
-			.with(EnvFilter::from("tokio=trace,runtime=trace"))
-			.with(console_layer)
-	};
-	#[cfg(not(feature = "tokio-console"))]
 	let trace_sub = { tracing_subscriber::Registry::default() };
 	trace_sub.with(ErrorLayer::default()).with(final_layer).init();
 	Ok(())

--- a/odilia/src/logging.rs
+++ b/odilia/src/logging.rs
@@ -5,14 +5,17 @@
 
 use std::io;
 
-use odilia_common::settings::{log::LoggingKind, ApplicationConfig};
+use odilia_common::{
+	errors::OdiliaError,
+	settings::{log::LoggingKind, ApplicationConfig},
+};
 use tracing_error::ErrorLayer;
 use tracing_subscriber::prelude::*;
 use tracing_tree::{time::Uptime, HierarchicalLayer};
 
 /// Initialise the logging stack
 /// this requires an application configuration structure, so configuration must be initialized before logging is
-pub fn init(config: &ApplicationConfig) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+pub fn init(config: &ApplicationConfig) -> Result<(), OdiliaError> {
 	let tree = HierarchicalLayer::new(4)
 		.with_bracketed_fields(true)
 		.with_targets(true)

--- a/odilia/src/logging.rs
+++ b/odilia/src/logging.rs
@@ -28,7 +28,6 @@ pub fn init(config: &ApplicationConfig) -> Result<(), OdiliaError> {
 	//this requires boxing because the types returned by this match block would be incompatible otherwise, since we return different layers, or modifications to a layer depending on what we get from the configuration. It is possible to do it otherwise, hopefully, but for now this  would do
 	let final_layer = match &config.log.logger {
 		LoggingKind::File(path) => {
-			tracing::info!("creating log file '{}'", path.display());
 			let file = std::fs::File::create(path)?;
 			tree.with_writer(file).boxed()
 		}

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -445,12 +445,12 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	state.add_child_proc(child).expect("Able to add child to process!");
 
 	let joined_tasks = (
-		ex.spawn(ssip_event_receiver),
-		ex.spawn(notification_task),
-		ex.spawn(atspi_handlers_task),
-		ex.spawn(event_send_task),
-		ex.spawn(input_task),
-		ex.spawn(input_handler),
+		ssip_event_receiver,
+		notification_task,
+		atspi_handlers_task,
+		event_send_task,
+		input_task,
+		input_handler,
 	)
 		.join();
 	ex.spawn(sigterm_signal_watcher(token, Arc::clone(&state))).detach();

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -333,11 +333,11 @@ async fn caret_moved(
 
 static EXECUTOR: StaticExecutor = StaticExecutor::new();
 
-fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+fn main() -> Result<(), OdiliaError> {
 	block_on(EXECUTOR.run(async_main()))
 }
 
-async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn async_main() -> Result<(), OdiliaError> {
 	let ex = &EXECUTOR;
 	let args = Args::from_cli_args()?;
 
@@ -459,9 +459,7 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	Ok(())
 }
 
-fn load_configuration(
-	cli_overide: Option<PathBuf>,
-) -> Result<ApplicationConfig, OdiliaError> {
+fn load_configuration(cli_overide: Option<PathBuf>) -> Result<ApplicationConfig, OdiliaError> {
 	// In order, do  a configuration file specified via cli, XDG_CONFIG_HOME, the usual location for system wide configuration(/etc/odilia/config.toml)
 	// If XDG_CONFIG_HOME based configuration wasn't found, create one by combining default values with the system provided ones, if available, for the user to alter, for the next run of odilia
 	//default configuration first, because that doesn't affect the priority outlined above

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -159,7 +159,7 @@ async fn sigterm_signal_watcher(
 		.instrument(tracing::debug_span!("Watching for Ctrl+C"))
 		.await;
 	tracing::debug!("Asking all processes to stop.");
-	(*state.children_pids.lock().expect("Able to lock mutex!"))
+	(*state.children_pids.lock().expect("Unable to lock mutex!"))
 		.iter_mut()
 		.try_for_each(Child::kill)
 		.expect("Able to kill child processes");
@@ -487,7 +487,5 @@ fn load_configuration(cli_overide: Option<PathBuf>) -> Result<ApplicationConfig,
 			path.to_str().expect("Valid UTF-8 path"),
 		));
 	}
-	let fin = config.build()?.try_deserialize()?;
-
-	Ok(fin)
+	Ok(config.build()?.try_deserialize()?)
 }

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -94,9 +94,7 @@ where
 
 /// Try to spawn the `odilia-input-server-*` binary.
 #[tracing::instrument]
-fn try_spawn_input_server(
-	input: &InputMethod,
-) -> Result<Child, Box<dyn std::error::Error + Send + Sync>> {
+fn try_spawn_input_server(input: &InputMethod) -> Result<Child, OdiliaError> {
 	let bin_name = format!(
 		"{}-{}",
 		"odilia-input-server",
@@ -129,7 +127,7 @@ fn try_spawn_input_server(
 async fn notifications_monitor(
 	state: Arc<ScreenReaderState>,
 	shutdown: CancellationToken,
-) -> Result<(), Box<dyn std::error::Error + Sync + Send>> {
+) -> Result<(), OdiliaError> {
 	let mut stream = listen_to_dbus_notifications()
 		.instrument(tracing::info_span!("creating notification listener"))
 		.await?;
@@ -154,7 +152,7 @@ async fn notifications_monitor(
 async fn sigterm_signal_watcher(
 	token: CancellationToken,
 	state: Arc<ScreenReaderState>,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<(), OdiliaError> {
 	let timeout_duration = Duration::from_secs(5); //todo: perhaps take this from the configuration file at some point
 	let mut signals = Signals::new([Signal::Int])?;
 	signals.next()
@@ -463,7 +461,7 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
 fn load_configuration(
 	cli_overide: Option<PathBuf>,
-) -> Result<ApplicationConfig, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<ApplicationConfig, OdiliaError> {
 	// In order, do  a configuration file specified via cli, XDG_CONFIG_HOME, the usual location for system wide configuration(/etc/odilia/config.toml)
 	// If XDG_CONFIG_HOME based configuration wasn't found, create one by combining default values with the system provided ones, if available, for the user to alter, for the next run of odilia
 	//default configuration first, because that doesn't affect the priority outlined above

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -26,8 +26,10 @@ use std::{
 use async_channel::bounded;
 use async_executor::StaticExecutor;
 use async_signal::{Signal, Signals};
-use atspi::RelationType;
-use atspi_common::events::{document, object};
+use atspi::{
+	events::{document, object},
+	RelationType,
+};
 use futures_concurrency::future::{Join, TryJoin};
 use futures_lite::{
 	future::{block_on, FutureExt},
@@ -352,7 +354,7 @@ async fn async_main() -> Result<(), OdiliaError> {
 	tracing::info!(?config, "this configuration was used to prepair odilia");
 
 	// Make sure applications with dynamic accessibility support do expose their AT-SPI2 interfaces.
-	if let Err(e) = atspi_connection::set_session_accessibility(true)
+	if let Err(e) = atspi::connection::set_session_accessibility(true)
 		.instrument(tracing::info_span!("setting accessibility enabled flag"))
 		.await
 	{

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -27,9 +27,9 @@ use async_io::Timer;
 use async_signal::{Signal, Signals};
 use atspi::RelationType;
 use atspi_common::events::{document, object};
-use futures::FutureExt as FatExt;
 use futures_concurrency::future::TryJoin;
 use futures_lite::{future::FutureExt, stream::StreamExt};
+use futures_util::FutureExt as FatExt;
 use odilia_common::{
 	command::{CaretPos, Focus, OdiliaCommand, SetState, Speak, TryIntoCommands},
 	errors::OdiliaError,

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -22,7 +22,11 @@ use std::{
 	time::Duration,
 };
 
+use async_channel::bounded;
+use async_io::Timer;
+use async_signal::{Signal, Signals};
 use atspi::RelationType;
+use atspi_common::events::{document, object};
 use futures::FutureExt as FatExt;
 use futures_concurrency::future::TryJoin;
 use futures_lite::{future::FutureExt, stream::StreamExt};
@@ -32,16 +36,10 @@ use odilia_common::{
 	events::{ChangeMode, ScreenReaderEvent, StopSpeech, StructuralNavigation},
 	settings::{ApplicationConfig, InputMethod},
 };
-
-use async_channel::bounded;
-use async_io::Timer;
-use async_signal::{Signal, Signals};
 use odilia_notify::listen_to_dbus_notifications;
-use ssip::{Priority, Request as SSIPRequest};
 use smol_cancellation_token::CancellationToken;
+use ssip::{Priority, Request as SSIPRequest};
 use tokio_util::task::TaskTracker;
-
-use atspi_common::events::{document, object};
 use tracing::Instrument;
 
 use crate::{

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -5,6 +5,7 @@ use std::{
 	sync::{atomic::AtomicUsize, Arc, Mutex},
 };
 
+use async_channel::Sender;
 use atspi_common::{
 	events::{DBusMatchRule, EventProperties, RegistryEventString},
 	Event,
@@ -12,7 +13,6 @@ use atspi_common::{
 use atspi_connection::AccessibilityConnection;
 use atspi_proxies::{accessible::AccessibleProxy, cache::CacheProxy};
 use circular_queue::CircularQueue;
-use eyre::WrapErr;
 use futures::future::{err, ok, Ready};
 use odilia_cache::{AccessibleExt, Cache as InnerCache, CacheItem, Convertable};
 use odilia_common::{
@@ -25,7 +25,6 @@ use odilia_common::{
 	Result as OdiliaResult,
 };
 use ssip_client_async::{MessageScope, Priority, PunctuationMode, Request as SSIPRequest};
-use tokio::sync::mpsc::Sender;
 use tracing::{debug, Instrument, Level};
 use zbus::{
 	fdo::DBusProxy, message::Type as MessageType, names::BusName, zvariant::ObjectPath,

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -13,7 +13,7 @@ use atspi_common::{
 use atspi_connection::AccessibilityConnection;
 use atspi_proxies::{accessible::AccessibleProxy, cache::CacheProxy};
 use circular_queue::CircularQueue;
-use futures::future::{err, ok, Ready};
+use futures_util::future::{err, ok, Ready};
 use odilia_cache::{AccessibleExt, Cache as InnerCache, CacheItem, Convertable};
 use odilia_common::{
 	cache::AccessiblePrimitive,

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -47,14 +47,14 @@ pub(crate) struct ScreenReaderState {
 	pub previous_caret_position: Arc<AtomicUsize>,
 	pub accessible_history: Arc<Mutex<CircularQueue<AccessiblePrimitive>>>,
 	pub event_history: Mutex<CircularQueue<Event>>,
-	pub cache: Arc<InnerCache>,
+	pub cache: Arc<InnerCache<zbus::Connection>>,
 	pub config: Arc<ApplicationConfig>,
 	pub children_pids: Arc<Mutex<Vec<Child>>>,
 }
 #[derive(Debug, Clone)]
 pub struct AccessibleHistory(pub Arc<Mutex<CircularQueue<AccessiblePrimitive>>>);
 #[derive(Debug, Clone)]
-pub struct Cache(pub Arc<InnerCache>);
+pub struct Cache(pub Arc<InnerCache<zbus::Connection>>);
 
 impl<C> TryFromState<Arc<ScreenReaderState>, C> for AccessibleHistory {
 	type Error = OdiliaError;
@@ -248,9 +248,7 @@ impl ScreenReaderState {
 		event: &T,
 	) -> OdiliaResult<CacheItem> {
 		let prim = AccessiblePrimitive::from_event(event);
-		self.cache
-			.get_or_create(&prim, self.atspi.connection(), Arc::clone(&self.cache))
-			.await
+		self.cache.get_or_create(&prim).await
 	}
 
 	// TODO: use cache; this will uplift performance MASSIVELY, also TODO: use this function instad of manually generating speech every time.

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -6,12 +6,12 @@ use std::{
 };
 
 use async_channel::Sender;
-use atspi_common::{
+use atspi::{
+	connection::AccessibilityConnection,
 	events::{DBusMatchRule, EventProperties, RegistryEventString},
+	proxy::{accessible::AccessibleProxy, cache::CacheProxy},
 	Event,
 };
-use atspi_connection::AccessibilityConnection;
-use atspi_proxies::{accessible::AccessibleProxy, cache::CacheProxy};
 use circular_queue::CircularQueue;
 use futures_util::future::{err, ok, Ready};
 use odilia_cache::{AccessibleExt, Cache as InnerCache, CacheItem, Convertable};

--- a/odilia/src/tower/choice.rs
+++ b/odilia/src/tower/choice.rs
@@ -59,7 +59,7 @@ where
 	pub fn new() -> Self {
 		ChoiceService { services: BTreeMap::new(), _marker: PhantomData }
 	}
-	pub fn entry(&mut self, k: K) -> Entry<K, S>
+	pub fn entry(&mut self, k: K) -> Entry<'_, K, S>
 	where
 		K: Ord,
 	{

--- a/odilia/src/tower/choice.rs
+++ b/odilia/src/tower/choice.rs
@@ -9,7 +9,7 @@ use atspi::{
 	events::{DBusInterface, DBusMember},
 	Event, EventTypeProperties,
 };
-use futures::{
+use futures_util::{
 	future::{err, Either, ErrInto, Ready},
 	TryFutureExt,
 };

--- a/odilia/src/tower/extractors/cache_event.rs
+++ b/odilia/src/tower/extractors/cache_event.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, future::Future, marker::PhantomData, pin::Pin, sync::Arc};
 
-use atspi_common::EventProperties;
+use atspi::EventProperties;
 use derived_deref::{Deref, DerefMut};
 use odilia_cache::CacheItem;
 use refinement::Predicate;

--- a/odilia/src/tower/extractors/event_property.rs
+++ b/odilia/src/tower/extractors/event_property.rs
@@ -40,7 +40,7 @@ pub trait PropertyType {
 pub trait GetProperty<P: PropertyType>: Sized {
 	fn get_property(
 		&self,
-		cache: &Cache,
+		cache: &Cache<zbus::Connection>,
 	) -> impl Future<Output = Result<EventProp<P>, OdiliaError>> + Send;
 }
 

--- a/odilia/src/tower/extractors/relation_set.rs
+++ b/odilia/src/tower/extractors/relation_set.rs
@@ -13,7 +13,10 @@ impl PropertyType for RelationSet {
 }
 
 impl GetProperty<RelationSet> for CacheItem {
-	async fn get_property(&self, cache: &Cache) -> Result<EventProp<RelationSet>, OdiliaError> {
+	async fn get_property(
+		&self,
+		cache: &Cache<zbus::Connection>,
+	) -> Result<EventProp<RelationSet>, OdiliaError> {
 		Ok(EventProp(self.relation_set.unchecked_into_cache_items(cache)))
 	}
 }

--- a/odilia/src/tower/handler.rs
+++ b/odilia/src/tower/handler.rs
@@ -95,11 +95,12 @@ trait FutureExt2: Future {
 }
 impl<F> FutureExt2 for F where F: Future {}
 
-#[pin_project::pin_project]
-pub struct MapOk<F, E, O> {
-	#[pin]
-	f: F,
-	_marker: PhantomData<(O, E)>,
+pin_project_lite::pin_project! {
+    pub struct MapOk<F, E, O> {
+      #[pin]
+      f: F,
+      _marker: PhantomData<(O, E)>,
+    }
 }
 impl<F, E, O> Future for MapOk<F, E, O>
 where

--- a/odilia/src/tower/handlers.rs
+++ b/odilia/src/tower/handlers.rs
@@ -2,8 +2,8 @@
 
 use std::{fmt::Debug, sync::Arc};
 
+use async_channel::Receiver;
 use atspi::{AtspiError, Event, EventProperties, EventTypeProperties};
-use futures::{Stream, StreamExt};
 use odilia_common::{
 	command::{
 		CommandType, OdiliaCommand as Command,
@@ -12,11 +12,10 @@ use odilia_common::{
 	errors::OdiliaError,
 	events::{EventType, ScreenReaderEvent, ScreenReaderEventDiscriminants},
 };
-use tokio::sync::mpsc::Receiver;
 use tower::{util::BoxCloneService, Service, ServiceExt};
 
 use crate::{
-  or_cancel,
+	or_cancel,
 	state::ScreenReaderState,
 	tower::{
 		async_try::AsyncTryFrom,

--- a/odilia/src/tower/service_ext.rs
+++ b/odilia/src/tower/service_ext.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, sync::Arc};
+use std::{convert::Infallible, future::Future, sync::Arc};
 
 use tower::{Layer, Service};
 
@@ -19,7 +19,7 @@ pub trait ServiceExt<Request>: Service<Request> {
 		Self: Service<Request, Response = R, Future = Fut1> + Sized,
 		I: TryInto<Request>,
 		E: From<<I as TryInto<Request>>::Error>,
-		Fut1: futures::future::Future<Output = Result<R, E>>,
+		Fut1: Future<Output = Result<R, E>>,
 	{
 		TryIntoLayer::new().layer(self)
 	}

--- a/odilia/src/tower/state_changed.rs
+++ b/odilia/src/tower/state_changed.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use atspi_common::{
+use atspi::{
 	events::{
 		object::StateChangedEvent, DBusInterface, DBusMatchRule, DBusMember,
 		DBusProperties, MessageConversion, RegistryEventString,

--- a/podman/install-deps.sh
+++ b/podman/install-deps.sh
@@ -1,3 +1,3 @@
 export DEBIAN_FRONTEND="noninteractive"
 apt update
-apt install -y libevdev-dev linux-headers-generic clang dbus-x11 dunst xvfb ydotool
+apt install -y libevdev-dev linux-headers-generic clang dbus-x11 dunst xvfb

--- a/podman/install-deps.sh
+++ b/podman/install-deps.sh
@@ -1,3 +1,3 @@
 export DEBIAN_FRONTEND="noninteractive"
 apt update
-apt install -y libevdev-dev linux-headers-generic clang dbus-x11 dunst xvfb
+apt install -y libevdev-dev linux-headers-generic clang dbus-x11 dunst xvfb ydotool

--- a/podman/test-wrapper.sh
+++ b/podman/test-wrapper.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 xvfb-run dunst --screen 0 600x400x8 &
-ydotoold &
 
 # Start DBus session and grab env
 #export DBUS_SESSION_BUS_ADDRESS="$(dbus-daemon --session --print-address --fork)"

--- a/podman/test-wrapper.sh
+++ b/podman/test-wrapper.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 xvfb-run dunst --screen 0 600x400x8 &
+ydotoold &
 
 # Start DBus session and grab env
 #export DBUS_SESSION_BUS_ADDRESS="$(dbus-daemon --session --print-address --fork)"

--- a/tower-iter/Cargo.toml
+++ b/tower-iter/Cargo.toml
@@ -10,9 +10,9 @@ keywords = ["tower"]
 categories = ["tower"]
 
 [dependencies]
-futures.workspace = true
-pin-project.workspace = true
-tower.workspace = true
+futures-util.workspace = true
+pin-project-lite.workspace = true
+tower = { workspace = true, features = ["util"] }
 
 [features]
 

--- a/tower-iter/Cargo.toml
+++ b/tower-iter/Cargo.toml
@@ -17,4 +17,4 @@ tower = { workspace = true, features = ["util"] }
 [features]
 
 [dev-dependencies]
-futures-lite = { version = "2.6.0", default-features = false, features = ["std"] }
+futures-lite.workspace = true

--- a/tower-iter/src/call_iter.rs
+++ b/tower-iter/src/call_iter.rs
@@ -7,6 +7,7 @@ use core::{
 	task::{Context, Poll},
 };
 
+use pin_project_lite::pin_project;
 use tower::{
 	util::{Oneshot, ReadyOneshot},
 	Service, ServiceExt,
@@ -57,12 +58,14 @@ impl<F, Res, E> ServiceCall<F, Res, E> {
 	}
 }
 
-#[pin_project::pin_project]
-pub struct ServiceCall<F, Res, E> {
-	#[pin]
-	f: F,
-	_marker: PhantomData<Result<Res, E>>,
+pin_project! {
+    pub struct ServiceCall<F, Res, E> {
+      #[pin]
+      f: F,
+      _marker: PhantomData<Result<Res, E>>,
+    }
 }
+
 impl<F, Res, E> Future for ServiceCall<F, Res, E>
 where
 	F: Future<Output = Result<Res, E>>,

--- a/tower-iter/src/future_ext.rs
+++ b/tower-iter/src/future_ext.rs
@@ -7,22 +7,20 @@ use core::{
 };
 use std::vec::Vec;
 
-use futures::{
-	future::{join_all, Either, JoinAll},
-	FutureExt as OtherFutExt,
-};
-use pin_project::pin_project;
+use futures_util::future::{join_all, Either, FutureExt as OtherFutExt, JoinAll};
+use pin_project_lite::pin_project;
 use tower::{util::Oneshot, Service};
 
 use crate::service_multi_iter::ServiceMultiIter;
 
-#[pin_project]
-pub struct MapFutureMultiSet<F, S, Lf, Lo, E> {
-	#[pin]
-	inner: F,
-	svc: S,
-	_marker: PhantomData<fn(Lf) -> Lo>,
-	_marker2: PhantomData<fn(S) -> E>,
+pin_project! {
+    pub struct MapFutureMultiSet<F, S, Lf, Lo, E> {
+      #[pin]
+      inner: F,
+      svc: S,
+      _marker: PhantomData<fn(Lf) -> Lo>,
+      _marker2: PhantomData<fn(S) -> E>,
+    }
 }
 impl<F, S, Lf, Lo, E> Future for MapFutureMultiSet<F, S, Lf, Lo, E>
 where
@@ -74,16 +72,17 @@ pub trait FutureExt<O, E>: Future<Output = O> {
 		MapOk { f: self, _marker: PhantomData }
 	}
 }
-#[pin_project]
-pub struct OkJoinAll<F, E, O, Iter, I>
-where
-	I: Future,
-{
-	#[pin]
-	f: F,
-	#[pin]
-	res: Option<JoinAll<I>>,
-	_marker: PhantomData<(O, E, Iter, I)>,
+pin_project! {
+    pub struct OkJoinAll<F, E, O, Iter, I>
+    where
+      I: Future,
+    {
+      #[pin]
+      f: F,
+      #[pin]
+      res: Option<JoinAll<I>>,
+      _marker: PhantomData<(O, E, Iter, I)>,
+    }
 }
 impl<F, E, O, Iter, I> Future for OkJoinAll<F, E, O, Iter, I>
 where
@@ -109,12 +108,14 @@ where
 	}
 }
 
-#[pin_project]
-pub struct MapOk<F, E, O> {
-	#[pin]
-	f: F,
-	_marker: PhantomData<(O, E)>,
+pin_project! {
+    pub struct MapOk<F, E, O> {
+      #[pin]
+      f: F,
+      _marker: PhantomData<(O, E)>,
+    }
 }
+
 impl<F, E, O> Future for MapOk<F, E, O>
 where
 	F: Future<Output = O>,

--- a/tower-iter/src/service_multi_iter.rs
+++ b/tower-iter/src/service_multi_iter.rs
@@ -1,7 +1,7 @@
 use core::{future::IntoFuture, iter::Zip, marker::PhantomData};
 use std::vec::Vec;
 
-use futures::future::{join_all, JoinAll};
+use futures_util::future::{join_all, JoinAll};
 use tower::Service;
 
 use crate::{call_iter::MapServiceCall, MapMExt};

--- a/tower-iter/src/service_multiset.rs
+++ b/tower-iter/src/service_multiset.rs
@@ -6,7 +6,7 @@ use core::{
 };
 use std::vec::Vec;
 
-use futures::future::{join_all, JoinAll};
+use futures_util::future::{join_all, JoinAll};
 use tower::Service;
 
 use crate::{call_iter::MapServiceCall, FutureExt, MapMExt, MapOk};

--- a/tower-iter/src/service_set.rs
+++ b/tower-iter/src/service_set.rs
@@ -5,7 +5,7 @@ use core::{
 };
 use std::vec::Vec;
 
-use futures::future::{join_all, JoinAll};
+use futures_util::future::{join_all, JoinAll};
 use tower::Service;
 
 use crate::{call_iter::MapServiceCall, FutureExt, MapMExt, MapOk};

--- a/tts/Cargo.toml
+++ b/tts/Cargo.toml
@@ -17,3 +17,5 @@ tracing.workspace = true
 odilia-common.workspace = true
 smol-cancellation-token.workspace = true
 async-channel = { version = "2.3.1", default-features = false }
+futures.workspace = true
+futures-lite = "2.6.0"

--- a/tts/Cargo.toml
+++ b/tts/Cargo.toml
@@ -12,10 +12,12 @@ edition = "2021"
 
 [dependencies]
 ssip-client-async.workspace = true
-tokio.workspace = true
 tracing.workspace = true
 odilia-common.workspace = true
 smol-cancellation-token.workspace = true
 async-channel = { version = "2.3.1", default-features = false }
 futures.workspace = true
 futures-lite = "2.6.0"
+async-io = "2.4.1"
+async-net = "2.0.0"
+async-fs = "2.1.2"

--- a/tts/Cargo.toml
+++ b/tts/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 ssip-client-async.workspace = true
 tracing = { workspace = true, features = ["attributes"] }
 smol-cancellation-token.workspace = true
-async-channel = { version = "2.3.1", default-features = false }
-futures.workspace = true
-futures-lite = "2.6.0"
-async-net = "2.0.0"
+async-channel.workspace = true
+async-net.workspace = true
+futures-lite.workspace = true
+futures-util.workspace = true

--- a/tts/Cargo.toml
+++ b/tts/Cargo.toml
@@ -18,3 +18,4 @@ async-channel.workspace = true
 async-net.workspace = true
 futures-lite.workspace = true
 futures-util.workspace = true
+odilia-common.workspace = true

--- a/tts/Cargo.toml
+++ b/tts/Cargo.toml
@@ -12,12 +12,9 @@ edition = "2021"
 
 [dependencies]
 ssip-client-async.workspace = true
-tracing.workspace = true
-odilia-common.workspace = true
+tracing = { workspace = true, features = ["attributes"] }
 smol-cancellation-token.workspace = true
 async-channel = { version = "2.3.1", default-features = false }
 futures.workspace = true
 futures-lite = "2.6.0"
-async-io = "2.4.1"
 async-net = "2.0.0"
-async-fs = "2.1.2"

--- a/tts/src/lib.rs
+++ b/tts/src/lib.rs
@@ -17,6 +17,7 @@ use async_channel::Receiver;
 use async_net::unix::UnixStream;
 use futures_lite::{io::BufReader, FutureExt};
 use futures_util::FutureExt as FatExt;
+use odilia_common::errors::OdiliaError;
 use smol_cancellation_token::CancellationToken;
 use ssip_client_async::{
 	async_io::AsyncClient, fifo::asynchronous_async_io::Builder, ClientName, Request,
@@ -37,8 +38,7 @@ where
 /// There may be errors when trying to send the initial registration command, or when parsing the response.
 #[tracing::instrument(level = "debug", err)]
 pub async fn create_ssip_client(
-) -> Result<AsyncClient<BufReader<UnixStream>, UnixStream>, Box<dyn std::error::Error + Send + Sync>>
-{
+) -> Result<AsyncClient<BufReader<UnixStream>, UnixStream>, OdiliaError> {
 	tracing::debug!("Attempting to register SSIP client odilia:speech");
 	let mut ssip_core =
 		match Builder::default().build().await {

--- a/tts/src/lib.rs
+++ b/tts/src/lib.rs
@@ -10,6 +10,7 @@
 
 use std::{
 	io::ErrorKind,
+	pin::pin,
 	process::{exit, Command, Stdio},
 };
 
@@ -85,8 +86,8 @@ pub async fn handle_ssip_commands(
 	mut client: AsyncClient<BufReader<UnixStream>, UnixStream>,
 	mut requests: Receiver<Request>,
 	shutdown: CancellationToken,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-	std::pin::pin!(&mut requests);
+) -> Result<(), OdiliaError> {
+	pin!(&mut requests);
 	loop {
 		let maybe_request = or_cancel(requests.recv(), &shutdown).await;
 		let Ok(request_option) = maybe_request else {

--- a/tts/src/lib.rs
+++ b/tts/src/lib.rs
@@ -8,6 +8,11 @@
 )]
 #![allow(clippy::multiple_crate_versions)]
 
+use std::{
+	io::ErrorKind,
+	process::{exit, Command, Stdio},
+};
+
 use async_channel::Receiver;
 use async_net::unix::UnixStream;
 use futures::FutureExt as FatExt;
@@ -15,10 +20,6 @@ use futures_lite::{io::BufReader, FutureExt};
 use smol_cancellation_token::CancellationToken;
 use ssip_client_async::{
 	async_io::AsyncClient, fifo::asynchronous_async_io::Builder, ClientName, Request,
-};
-use std::{
-	io::ErrorKind,
-	process::{exit, Command, Stdio},
 };
 
 async fn or_cancel<F>(f: F, token: &CancellationToken) -> Result<F::Output, std::io::Error>

--- a/tts/src/lib.rs
+++ b/tts/src/lib.rs
@@ -15,8 +15,8 @@ use std::{
 
 use async_channel::Receiver;
 use async_net::unix::UnixStream;
-use futures::FutureExt as FatExt;
 use futures_lite::{io::BufReader, FutureExt};
+use futures_util::FutureExt as FatExt;
 use smol_cancellation_token::CancellationToken;
 use ssip_client_async::{
 	async_io::AsyncClient, fifo::asynchronous_async_io::Builder, ClientName, Request,


### PR DESCRIPTION
Overall: Reduce dependencies by 35% (~75), reduce compile times by 40% (1m35s -> 55s)

Details:

- Depends on `indextree-cache` being merged
- Remove `eyre`; it's not used in most of the codebase anyways.
    - Replaced with `Box<dyn Error>`; we can make this explicit errors if we want.
- Remove `clap`; it's a huge crate that we just don't need; replaced with `lexopt`.
- Remove `figment`; like `clap` it's a very large crate that takes a lot of binary space (>5% upon last meassurement). Replaced with `config` which leverages `serde` and is much smaller.
- Remove `which` by just implementing 2 functions ourselves.
- Remove `tokio`, `tokio-console`, and related deps. Replace with `async-io`, `async-net`, `async-executor`, `async-fs`, etc. from the `smol-rs` guys.
- Remove `futures` in favour of `futures_util`, `futures_lite`, or `futures_concurrency` as required.