### PR TITLE
Add Navigation Capabilites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,8 +228,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "atspi"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e595c4a1ad7be9c5514980ae8c6e4810f17e9d24bd7bbc5ad67e7aef4dc1c819"
+source = "git+https://github.com/odilia-app/atspi/?branch=object-match-improvments#401c340de5a3bb89130b7213386a42ce4ac254f2"
 dependencies = [
  "atspi-common",
  "atspi-connection",
@@ -239,8 +238,7 @@ dependencies = [
 [[package]]
 name = "atspi-common"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2b4e5cb03df74eae47d7c47918e109db6ad3c825602f236d060a221f4d23b8"
+source = "git+https://github.com/odilia-app/atspi/?branch=object-match-improvments#401c340de5a3bb89130b7213386a42ce4ac254f2"
 dependencies = [
  "enumflags2",
  "serde",
@@ -255,8 +253,7 @@ dependencies = [
 [[package]]
 name = "atspi-connection"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832ecc699b7b1e801e49f5dccb4db1472519537498448f944e8cdcfcdd92e6b3"
+source = "git+https://github.com/odilia-app/atspi/?branch=object-match-improvments#401c340de5a3bb89130b7213386a42ce4ac254f2"
 dependencies = [
  "atspi-common",
  "atspi-proxies",
@@ -267,8 +264,7 @@ dependencies = [
 [[package]]
 name = "atspi-proxies"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b9aef6811420186bed52af0af10fed051ef554b6206edbaffddcfa2dd90e43"
+source = "git+https://github.com/odilia-app/atspi/?branch=object-match-improvments#401c340de5a3bb89130b7213386a42ce4ac254f2"
 dependencies = [
  "atspi-common",
  "serde",
@@ -1044,9 +1040,9 @@ checksum = "9fa0e2a1fcbe2f6be6c42e342259976206b383122fc152e872795338b5a3f3a7"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1302,6 +1298,7 @@ dependencies = [
  "futures-util",
  "fxhash",
  "odilia-common",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "serde_plain",
@@ -1568,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "beef09f85ae72cea1ef96ba6870c51e6382ebfa4f0e85b643459331f3daa5be0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1774,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -2765,6 +2762,7 @@ dependencies = [
  "hex",
  "nix",
  "ordered-stream",
+ "rand",
  "serde",
  "serde_repr",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
+checksum = "09f7e37c0ed80b2a977691c47dae8625cfb21e205827106c64f7c588766b2e50"
 dependencies = [
  "async-lock",
  "blocking",
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -108,15 +108,14 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -136,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde3f4e40e6021d7acffc90095cbd6dc54cb593903d1de5832f435eb274b85dc"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
 dependencies = [
  "async-channel",
  "async-io",
@@ -150,7 +149,6 @@ dependencies = [
  "event-listener",
  "futures-lite",
  "rustix",
- "tracing",
 ]
 
 [[package]]
@@ -166,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7605a4e50d4b06df3898d5a70bf5fde51ed9059b0434b73105193bc27acce0d"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
 dependencies = [
  "async-io",
  "async-lock",
@@ -179,7 +177,7 @@ dependencies = [
  "rustix",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -342,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
  "async-channel",
  "async-task",
@@ -373,9 +371,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
 dependencies = [
  "shlex",
 ]
@@ -421,27 +419,27 @@ dependencies = [
 
 [[package]]
 name = "circular-queue"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d34327ead1c743a10db339de35fb58957564b99d248a67985c55638b22c59b5"
+checksum = "2df8276ab95fe8665a814190345239d91105df5df0fda26ddc7784c96244dc76"
 dependencies = [
  "version_check",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -479,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.11"
+version = "0.15.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595aae20e65c3be792d05818e8c63025294ac3cb7e200f11459063a352a6ef80"
+checksum = "5b1eb4fb07bc7f012422df02766c7bd5971effb894f573865642f06fa3265440"
 dependencies = [
  "pathdiff",
  "serde",
@@ -692,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "epoll"
-version = "4.3.3"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74351c3392ea1ff6cd2628e0042d268ac2371cb613252ff383b6dfa50d22fa79"
+checksum = "e74d68fe2927dbf47aa976d14d93db9b23dced457c7bb2bdc6925a16d31b736e"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -741,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -795,9 +793,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "futures-buffered"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe940397c8b744b9c2c974791c2c08bca2c3242ce0290393249e98f215a00472"
+checksum = "a8e0e1f38ec07ba4abbde21eed377082f17ccb988be9d988a5adbf4bafc118fd"
 dependencies = [
  "cordyceps",
  "diatomic-waker",
@@ -835,9 +833,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -901,17 +899,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -940,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "heck"
@@ -995,6 +982,17 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
  "libc",
 ]
 
@@ -1130,10 +1128,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.30.0"
+name = "mio"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537bc3c4a347b87fd52ac6c03a02ab1302962cfd93373c5d7a112cdc337854cc"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -1521,17 +1530,16 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.8.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
+checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1569,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -1629,20 +1637,19 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1650,18 +1657,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom",
 ]
 
 [[package]]
 name = "rand_xorshift"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core",
 ]
@@ -1748,9 +1755,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
@@ -1806,18 +1813,18 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "serde"
-version = "1.0.200"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.200"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1826,20 +1833,21 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.100"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_plain"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6018081315db179d0ce57b1fe4b62a12a0028c9cf9bbef868c9cf477b3c34ae"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
 dependencies = [
  "serde",
 ]
@@ -1857,9 +1865,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -1881,18 +1889,18 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -1902,9 +1910,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e635339259e51ef85ac7aa29a1cd991b957047507288697a690e80ab97d07cad"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -1929,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "ssip"
@@ -1961,23 +1969,22 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strum"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 
@@ -2000,9 +2007,9 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "sysinfo"
-version = "0.26.8"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ddf41e393a9133c81d5f0974195366bd57082deac6e0eb02ed39b8341c2bb6"
+checksum = "5c18a6156d1f27a9592ee18c1a846ca8dd5c258b7179fc193ae87c74ebb666f5"
 dependencies = [
  "cfg-if",
  "core-foundation-sys 0.8.7",
@@ -2031,7 +2038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -2039,18 +2046,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.0"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15291287e9bff1bc6f9ff3409ed9af665bec7a5fc8ac079ea96be07bca0e2668"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.0"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22efd00f33f93fa62848a7cab956c3d38c8d43095efda1decfc2b3a5dc0b8972"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2097,12 +2104,16 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
+ "io-uring",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "slab",
  "tokio-macros",
 ]
 
@@ -2119,14 +2130,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -2134,6 +2146,12 @@ name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
 dependencies = [
  "serde",
 ]
@@ -2145,9 +2163,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
  "winnow",
 ]
 
@@ -2189,9 +2214,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2221,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-journald"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba316a74e8fc3c3896a850dba2375928a9fa171b085ecddfc7c054d39970f3fd"
+checksum = "fc0b4143302cf1022dac868d521e36e8b27691f72c84b3311750d5188ebba657"
 dependencies = [
  "libc",
  "tracing-core",
@@ -2232,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
@@ -2243,9 +2268,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2544,7 +2569,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2565,10 +2590,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -2719,9 +2745,9 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "zbus"
-version = "5.8.0"
+version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597f45e98bc7e6f0988276012797855613cd8269e23b5be62cc4e5d28b7e515d"
+checksum = "4bb4f9a464286d42851d18a605f7193b8febaf5b0919d71c6399b7b26e5b0aad"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -2776,9 +2802,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.8.0"
+version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c8e4e14dcdd9d97a98b189cd1220f30e8394ad271e8c987da84f73693862c2"
+checksum = "ef9859f68ee0c4ee2e8cde84737c78e3f4c54f946f2a38645d0d4c7a95327659"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ pre-release-hook = ["cargo", "fmt"]
 dependent-version = "upgrade"
 
 [workspace.dependencies]
-atspi = { version = "0.27.0" }
+atspi = { version = "0.27.0", git = "https://github.com/odilia-app/atspi/", branch = "object-match-improvments" }
 config = { version = "0.15.11", default-features = false, features = ["toml"] }
 futures-concurrency = { version = "7.6.3", default-features = false, features = ["alloc"] }
 futures-lite = { version = "2.6.0", default-features = false }

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -25,6 +25,7 @@ async-channel.workspace = true
 smol-cancellation-token.workspace = true
 futures-util.workspace = true
 static_assertions = "1.1.0"
+pin-project-lite.workspace = true
 
 [dev-dependencies]
 atspi = { workspace = true, features = ["connection"] }

--- a/cache/src/event_handlers.rs
+++ b/cache/src/event_handlers.rs
@@ -30,9 +30,10 @@ use atspi::{
 		},
 		CacheEvents, Event, ObjectEvents,
 	},
-	DocumentEvents, KeyboardEvents, MouseEvents, Operation, State, TerminalEvents,
-	WindowEvents,
+	DocumentEvents, KeyboardEvents, MouseEvents, ObjectMatchRule, Operation, State,
+	TerminalEvents, WindowEvents,
 };
+use odilia_common::events::Direction;
 
 use crate::{
 	Cache, CacheDriver, CacheError, CacheItem, CacheKey, Future, OdiliaError, RelationType,
@@ -77,6 +78,21 @@ impl DerefMut for Item {
 }
 
 #[derive(Debug)]
+pub struct FoundItem(pub Option<CacheItem>);
+impl Deref for FoundItem {
+	type Target = Option<CacheItem>;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+impl DerefMut for FoundItem {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.0
+	}
+}
+
+#[derive(Debug)]
 pub struct Parent(pub CacheItem);
 
 #[derive(Debug)]
@@ -104,6 +120,12 @@ pub enum CacheRequest {
 	/// A request to add bulk items to the cache.
 	/// Only used for testing.
 	AddAll(Vec<CacheItem>),
+	/// Find a matching item starting at 0, in direction 1, with matching rule 2 within the boundary
+	/// of 3.
+	///
+	/// In some circumstances, this can take quite some time—seconds even if the cache is not
+	/// populated.
+	Find(CacheKey, Direction, Box<ObjectMatchRule>, Box<ObjectMatchRule>),
 }
 
 #[derive(Debug)]
@@ -115,6 +137,7 @@ pub enum CacheResponse {
 	/// A response that adding items to the cache succeeeded.
 	/// Only used for testing.
 	AddAll,
+	Find(FoundItem),
 }
 
 macro_rules! impl_relation {

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -11,7 +11,12 @@
 mod convertable;
 pub use convertable::Convertable;
 mod accessible_ext;
-use std::{collections::HashMap, fmt, fmt::Debug, future::Future};
+use std::{
+	collections::{HashMap, VecDeque},
+	fmt,
+	fmt::Debug,
+	future::Future,
+};
 mod relation_set;
 pub use relation_set::{RelationSet, Relations};
 mod event_handlers;
@@ -20,13 +25,14 @@ pub use accessible_ext::AccessibleExt;
 use async_channel::{Receiver, Sender};
 use atspi::{
 	proxy::{accessible::AccessibleProxy, cache::CacheProxy, text::TextProxy},
-	Event, EventProperties, InterfaceSet, ObjectRef, RelationType, Role, StateSet,
+	Event, EventProperties, InterfaceSet, MatchType, ObjectMatchRule, ObjectRef, RelationType,
+	Role, StateSet,
 };
 pub use event_handlers::{
 	CacheRequest, CacheResponse, Children, ConstRelationType, ControlledBy, ControllerFor,
 	DescribedBy, DescriptionFor, Details, DetailsFor, EmbeddedBy, Embeds, ErrorFor,
-	ErrorMessage, EventHandler, FlowsFrom, FlowsTo, Item, LabelFor, LabelledBy, MemberOf,
-	NodeChildOf, NodeParentOf, Parent, ParentWindowOf, PopupFor, SubwindowOf,
+	ErrorMessage, EventHandler, FlowsFrom, FlowsTo, FoundItem, Item, LabelFor, LabelledBy,
+	MemberOf, NodeChildOf, NodeParentOf, Parent, ParentWindowOf, PopupFor, SubwindowOf,
 };
 use futures_concurrency::future::TryJoin;
 use futures_lite::future::FutureExt as LiteExt;
@@ -35,6 +41,7 @@ use fxhash::FxBuildHasher;
 use odilia_common::{
 	cache::AccessiblePrimitive,
 	errors::{CacheError, OdiliaError},
+	events::Direction,
 	result::OdiliaResult,
 };
 use serde::{Deserialize, Serialize};
@@ -204,6 +211,51 @@ pub struct CacheItem {
 	/// The actual, internal text of the item; this will be `None` if either the text interface isn't
 	/// implemented, or if the response contains an empty string: "".
 	pub text: Option<String>,
+}
+
+impl CacheItem {
+	fn matches(&self, mr: &ObjectMatchRule) -> bool {
+		mr.invert
+			^ (match (mr.states_mt, mr.states.is_empty()) {
+				(MatchType::Invalid, _) => true,
+				(MatchType::All, _) | (MatchType::Empty, false) => {
+					(self.states & mr.states) == mr.states
+				}
+				(MatchType::Any, _) => !(self.states & mr.states).is_empty(),
+				(MatchType::NA, _) => (self.states & mr.states).is_empty(),
+				(MatchType::Empty, true) => self.states.is_empty(),
+			} && match (mr.ifaces_mt, mr.ifaces == InterfaceSet::empty()) {
+				(MatchType::Invalid, _) => true,
+				(MatchType::All, _) | (MatchType::Empty, false) => {
+					(self.interfaces & mr.ifaces) == mr.ifaces
+				}
+				(MatchType::Any, _) => {
+					(self.interfaces & mr.ifaces) != InterfaceSet::empty()
+				}
+				(MatchType::NA, _) => {
+					(self.interfaces & mr.ifaces) == InterfaceSet::empty()
+				}
+				(MatchType::Empty, true) => {
+					self.interfaces == InterfaceSet::empty()
+				}
+			} && match (mr.roles_mt, mr.roles.is_empty()) {
+				(MatchType::Invalid, _) => true,
+				(MatchType::All, _) | (MatchType::Empty, false) => {
+					mr.roles.iter().all(|r| *r == self.role)
+				}
+				(MatchType::Empty, true) => false,
+				(MatchType::Any, _) => mr.roles.iter().any(|r| *r == self.role),
+				(MatchType::NA, _) => !mr.roles.iter().any(|r| *r == self.role),
+			} && match (mr.attr_mt, mr.attr.is_empty()) {
+				(MatchType::Invalid, _) => true,
+				(MatchType::All, _) | (MatchType::Empty, false) => {
+					mr.roles.iter().all(|r| *r == self.role)
+				}
+				(MatchType::Empty, true) => false,
+				(MatchType::Any, _) => mr.roles.iter().any(|r| *r == self.role),
+				(MatchType::NA, _) => !mr.roles.iter().any(|r| *r == self.role),
+			})
+	}
 }
 
 /// An internal cache used within Odilia.
@@ -445,6 +497,29 @@ impl CacheDriver for zbus::Connection {
 }
 
 impl<D: CacheDriver + Send> Cache<D> {
+	async fn find(
+		&mut self,
+		start: CacheKey,
+		dir: Direction,
+		mr: ObjectMatchRule,
+	) -> Result<Option<CacheItem>, OdiliaError> {
+		// TODO: how do we bound certain types of searches?
+		// it seems to me that there is very little guidance on this.
+		//
+		// For example, searching for "the next button" in an HTML page should not include buttons
+		// that are part of the web browser menus, but using simple "next/prev" navigatinon does go
+		// to them.
+		//
+		// There is the possibility we need a boundary parameter too, in order to be consistent.
+		// We just need _something_ now.
+		let matching_item = None;
+		let mut stack: VecDeque<CacheKey> = VecDeque::new();
+		while let Some(key) = stack.pop_front() {
+			let item = self.get_or_create(&key).await?;
+			if item.matches(&mr) {}
+		}
+		Ok(matching_item)
+	}
 	async fn handle_event(&mut self, ev: Event) -> Result<CacheItem, OdiliaError> {
 		ev.handle_event(self).await
 	}
@@ -479,6 +554,10 @@ impl<D: CacheDriver + Send> Cache<D> {
 				let _ = self.add_all(items);
 				Ok(CacheResponse::AddAll)
 			}
+			CacheRequest::Find(start, direction, match_rule) => self
+				.find(start, direction, match_rule)
+				.await
+				.map(|item| CacheResponse::Find(FoundItem(item))),
 		}
 	}
 	pub fn tree(

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -215,6 +215,16 @@ pub struct CacheItem {
 
 impl CacheItem {
 	fn matches(&self, mr: &ObjectMatchRule) -> bool {
+		assert_eq!(
+			mr.attr,
+			HashMap::new(),
+			"Odilia does not implement support for attribute matching!"
+		);
+		assert_eq!(
+			mr.attr_mt,
+			MatchType::Invalid,
+			"Odilia does not implement support for attribute matching!"
+		);
 		mr.invert
 			^ (match (mr.states_mt, mr.states.is_empty()) {
 				(MatchType::Invalid, _) => true,
@@ -244,16 +254,8 @@ impl CacheItem {
 					mr.roles.iter().all(|r| *r == self.role)
 				}
 				(MatchType::Empty, true) => false,
-				(MatchType::Any, _) => mr.roles.iter().any(|r| *r == self.role),
-				(MatchType::NA, _) => !mr.roles.iter().any(|r| *r == self.role),
-			} && match (mr.attr_mt, mr.attr.is_empty()) {
-				(MatchType::Invalid, _) => true,
-				(MatchType::All, _) | (MatchType::Empty, false) => {
-					mr.roles.iter().all(|r| *r == self.role)
-				}
-				(MatchType::Empty, true) => false,
-				(MatchType::Any, _) => mr.roles.iter().any(|r| *r == self.role),
-				(MatchType::NA, _) => !mr.roles.iter().any(|r| *r == self.role),
+				(MatchType::Any, _) => mr.roles.contains(&self.role),
+				(MatchType::NA, _) => !mr.roles.contains(&self.role),
 			})
 	}
 }
@@ -497,26 +499,64 @@ impl CacheDriver for zbus::Connection {
 }
 
 impl<D: CacheDriver + Send> Cache<D> {
+	async fn next_siblings(
+		&mut self,
+		root: &CacheItem,
+		dir: Direction,
+	) -> Result<(VecDeque<CacheItem>, CacheItem), OdiliaError> {
+		let parent = self.get_or_create(&root.parent).await?;
+		let mut siblings: Vec<_> = self
+			.get_or_create_all(&parent.children)
+			.await?
+			.into_iter()
+			.filter(|sib| match dir {
+				Direction::Forward => sib.index > root.index,
+				Direction::Backward => sib.index < root.index,
+			})
+			.collect();
+		siblings.sort_by(|sib1, sib2| match dir {
+			Direction::Forward => sib1.index.cmp(&sib2.index),
+			Direction::Backward => sib2.index.cmp(&sib1.index),
+		});
+		assert_eq!({
+            let mut cl = siblings.clone();
+            cl.dedup_by_key(|sib| sib.index);
+            cl.len()
+        }, siblings.len(), "There are two elements with the same index! This is almost always an issue with the application's accessibility implementation: {siblings:?}");
+		Ok((siblings.into(), parent))
+	}
 	async fn find(
 		&mut self,
-		start: CacheKey,
+		start_key: CacheKey,
 		dir: Direction,
-		mr: ObjectMatchRule,
+		find_mr: ObjectMatchRule,
+		bound_mr: ObjectMatchRule,
 	) -> Result<Option<CacheItem>, OdiliaError> {
-		// TODO: how do we bound certain types of searches?
-		// it seems to me that there is very little guidance on this.
-		//
-		// For example, searching for "the next button" in an HTML page should not include buttons
-		// that are part of the web browser menus, but using simple "next/prev" navigatinon does go
-		// to them.
-		//
-		// There is the possibility we need a boundary parameter too, in order to be consistent.
-		// We just need _something_ now.
-		let matching_item = None;
-		let mut stack: VecDeque<CacheKey> = VecDeque::new();
-		while let Some(key) = stack.pop_front() {
-			let item = self.get_or_create(&key).await?;
-			if item.matches(&mr) {}
+		println!("FIND: START SEARCH");
+		let mut root = self.get_or_create(&start_key).await?;
+		let mut matching_item = None;
+		let mut stack: VecDeque<_> = self.get_or_create_all(&root.children).await?.into();
+		while stack.is_empty() {
+			println!("Trying parent for siblings");
+			(stack, root) = self.next_siblings(&root, dir).await?;
+			if root.matches(&bound_mr) {
+				return Ok(None);
+			}
+		}
+		while let Some(item) = stack.pop_front() {
+			println!("FIND: {item:?}");
+			if item.matches(&find_mr) {
+				matching_item = Some(item);
+				break;
+			}
+			if item.matches(&bound_mr) {
+				break;
+			}
+			if !stack.is_empty() {
+				continue;
+			}
+			// we can do this because the stack is empty
+			(stack, root) = self.next_siblings(&root, dir).await?;
 		}
 		Ok(matching_item)
 	}
@@ -538,12 +578,12 @@ impl<D: CacheDriver + Send> Cache<D> {
 			}
 			CacheRequest::Children(ref key) => {
 				let children_vec = self.get_or_create(key).await?.children;
-				let children = self.get_or_create_all(children_vec).await?;
+				let children = self.get_or_create_all(&children_vec).await?;
 				Ok(CacheResponse::Children(Children(children)))
 			}
 			CacheRequest::Relation(ref key, ty) => {
 				let rel_ids = self.driver.lookup_relations(key, ty).await?;
-				let rels = self.get_or_create_all(rel_ids).await?;
+				let rels = self.get_or_create_all(&rel_ids).await?;
 				Ok(CacheResponse::Relations(Relations(ty, rels)))
 			}
 			CacheRequest::EventHandler(event) => self
@@ -554,8 +594,12 @@ impl<D: CacheDriver + Send> Cache<D> {
 				let _ = self.add_all(items);
 				Ok(CacheResponse::AddAll)
 			}
-			CacheRequest::Find(start, direction, match_rule) => self
-				.find(start, direction, match_rule)
+			CacheRequest::Find(
+				start,
+				direction,
+				find_match_rule,
+				boundary_match_rule,
+			) => self.find(start, direction, *find_match_rule, *boundary_match_rule)
 				.await
 				.map(|item| CacheResponse::Find(FoundItem(item))),
 		}
@@ -636,17 +680,17 @@ impl<D: CacheDriver> Cache<D> {
 		self.get(key).ok_or(CacheError::NoItem.into())
 	}
 
-	async fn get_or_create_all(&mut self, keys: Vec<CacheKey>) -> OdiliaResult<Vec<CacheItem>> {
+	async fn get_or_create_all(&mut self, keys: &[CacheKey]) -> OdiliaResult<Vec<CacheItem>> {
 		let mut found = vec![];
 		let mut not_found = vec![];
 		for key in keys {
-			match self.tree.get(&key) {
+			match self.tree.get(key) {
 				Some(cache_item) => found.push(cache_item.clone()),
 				None => not_found.push(key),
 			}
 		}
 		for key in not_found {
-			let item = self.get_or_create(&key).await?;
+			let item = self.get_or_create(key).await?;
 			found.push(item);
 		}
 		Ok(self.add_all(found))

--- a/common/src/command.rs
+++ b/common/src/command.rs
@@ -53,6 +53,12 @@ pub trait IntoCommands {
 	fn into_commands(self) -> Self::Iter;
 }
 
+impl IntoCommands for Quit {
+	type Iter = IntoIter<OdiliaCommand, 1>;
+	fn into_commands(self) -> Self::Iter {
+		[self.into()].into_iter()
+	}
+}
 impl IntoCommands for CaretPos {
 	type Iter = IntoIter<OdiliaCommand, 1>;
 	fn into_commands(self) -> Self::Iter {
@@ -176,6 +182,9 @@ impl<T: CommandType> CommandTypeDynamic for T {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct Quit;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct CaretPos(pub usize);
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
@@ -203,6 +212,7 @@ impl_command_type!(Focus, Focus);
 impl_command_type!(SetState, SetState);
 impl_command_type!(Speak, Speak);
 impl_command_type!(CaretPos, CaretPos);
+impl_command_type!(Quit, Quit);
 
 #[derive(Debug, Clone, EnumDiscriminants, Serialize, Deserialize, Eq, PartialEq)]
 #[strum_discriminants(derive(Ord, PartialOrd, Display))]
@@ -212,4 +222,5 @@ pub enum OdiliaCommand {
 	Focus(Focus),
 	CaretPos(CaretPos),
 	SetState(SetState),
+	Quit(Quit),
 }

--- a/common/src/command.rs
+++ b/common/src/command.rs
@@ -190,8 +190,21 @@ pub struct CaretPos(pub usize);
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Speak(pub String, pub Priority);
 
+impl From<(Priority, &str)> for Speak {
+	fn from(ps: (Priority, &str)) -> Self {
+		Speak(ps.1.to_string(), ps.0)
+	}
+}
+impl From<(Priority, &str)> for OdiliaCommand {
+	fn from(ps: (Priority, &str)) -> Self {
+		Speak::from(ps).into()
+	}
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Focus(pub AccessiblePrimitive);
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct Move(pub AccessiblePrimitive);
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct SetState {
@@ -209,6 +222,7 @@ macro_rules! impl_command_type {
 }
 
 impl_command_type!(Focus, Focus);
+impl_command_type!(Move, Move);
 impl_command_type!(SetState, SetState);
 impl_command_type!(Speak, Speak);
 impl_command_type!(CaretPos, CaretPos);
@@ -220,6 +234,7 @@ impl_command_type!(Quit, Quit);
 pub enum OdiliaCommand {
 	Speak(Speak),
 	Focus(Focus),
+	Move(Move),
 	CaretPos(CaretPos),
 	SetState(SetState),
 	Quit(Quit),

--- a/common/src/events.rs
+++ b/common/src/events.rs
@@ -3,9 +3,9 @@ use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumDiscriminants};
 
-use crate::modes::ScreenReaderMode;
+use crate::{cache::AccessiblePrimitive, modes::ScreenReaderMode};
 
-#[derive(Eq, PartialEq, Clone, Hash, Serialize, Deserialize, Debug)]
+#[derive(Eq, PartialEq, Clone, Copy, Hash, Serialize, Deserialize, Debug)]
 /// A list of features supported natively by Odilia.
 pub enum Feature {
 	/// Unimplemented, but will eventually stop all speech until re-activated.
@@ -14,7 +14,7 @@ pub enum Feature {
 	Braille, // TODO
 }
 
-#[derive(Eq, PartialEq, Clone, Hash, Serialize, Deserialize, Debug)]
+#[derive(Eq, PartialEq, Clone, Copy, Hash, Serialize, Deserialize, Debug)]
 #[serde(tag = "direction")]
 pub enum Direction {
 	Forward,
@@ -67,7 +67,11 @@ pub struct Quit;
 impl_event_type!(Quit, Quit);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct Navigate(pub Direction, pub ObjectMatchRule);
+pub struct Navigate {
+	pub direction: Direction,
+	pub find: Box<ObjectMatchRule>,
+	pub bound: Box<ObjectMatchRule>,
+}
 impl_event_type!(Navigate, Navigate);
 
 #[derive(Eq, PartialEq, Clone, Serialize, Deserialize, Debug, EnumDiscriminants)]

--- a/common/src/events.rs
+++ b/common/src/events.rs
@@ -1,4 +1,4 @@
-use atspi::Role;
+use atspi::{ObjectMatchRule, Role};
 use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumDiscriminants};
@@ -66,6 +66,10 @@ impl_event_type!(StructuralNavigation, StructuralNavigation);
 pub struct Quit;
 impl_event_type!(Quit, Quit);
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Navigate(pub Direction, pub ObjectMatchRule);
+impl_event_type!(Navigate, Navigate);
+
 #[derive(Eq, PartialEq, Clone, Serialize, Deserialize, Debug, EnumDiscriminants)]
 /// Events which can be trigged through Odilia's external API.
 /// Subject to change without notice until v1.0, but we're [open to suggestions on our Github](https://github.com/odilia-app/odilia/); please reach out with features you'd like to see.
@@ -82,6 +86,8 @@ pub enum ScreenReaderEvent {
 	ChangeMode(ChangeMode),
 	/// Navigate to the next [`Role`] in [`Direction`] by depth-first search.
 	StructuralNavigation(StructuralNavigation),
+	/// Navigate to the next/prev match of the inner [`ObjectMatchRule`].
+	Navigate(Navigate),
 	/// Quit the screen reader.
 	Quit(Quit),
 }

--- a/input-server-keyboard/README.md
+++ b/input-server-keyboard/README.md
@@ -16,3 +16,15 @@ Here is what we use in our dev environment:
 ```bash
 PROPTEST_MAX_SHRINK_ITERS=10000 PROPTEST_CASES=1000 cargo test --release --all-features
 ```
+
+## How Does It Work?
+
+- We capture all kernel input events via special permissions given to users from `evdev`.
+- Generally, we pass through all events, unless one of the following cases are triggered:
+    1. The global activation key is pressed. This key, set to capslock by default, enables most of Odilia's commands. Any key pressed with the global activation key will be captured and not re-emitted.
+    2. Part of a key combination is pressed that _could_ lead to an event being triggered. This means that if you have an event like `Shift+h`, then `Shift` will _never_ be passed through to the application as it might be tha start of a key combo.
+    3. 2) is performed only if the requested mode is active.
+- We understand that \#2 is quite limiting, but we have some ways around this. For example, if you wanted to have `Ctrl+Shift+h` to be the action "move left and select the previous word", this could still be done without disruption to the user by making it only active in certain modes.
+- For example, you might only activate this combination in browse mode, since most editors will enable this with `Ctrl+Shift+Left Arrow` in any edit box.
+- I believe that this type of user interaction (replaying keys when they end up not matching a potential binding) are holding back screen reader users, because it inherently adds latency to their interaction with the computer. It also massivley expands the scope of what needs to be handled by the keyboard process.
+

--- a/input-server-keyboard/src/lib.rs
+++ b/input-server-keyboard/src/lib.rs
@@ -24,11 +24,11 @@ mod proptests;
 
 use std::{cmp::Ordering, sync::mpsc::SyncSender};
 
-use atspi::Role;
+use atspi::{MatchType, ObjectMatchRule, Role};
 use odilia_common::{
 	events::{
-		ChangeMode, Direction, Quit, ScreenReaderEvent as OdiliaEvent, StopSpeech,
-		StructuralNavigation,
+		ChangeMode, Direction, Navigate, Quit, ScreenReaderEvent as OdiliaEvent,
+		StopSpeech, StructuralNavigation,
 	},
 	modes::ScreenReaderMode as Mode,
 };
@@ -605,6 +605,40 @@ impl IntoIterator for ComboSets {
 	}
 }
 
+/// The containing roles.
+pub const SEMANTIC_ROLES: [Role; 30] = [
+	Role::Frame,
+	Role::DocumentFrame,
+	Role::DocumentWeb,
+	Role::Dialog,
+	Role::Alert,
+	Role::Panel,
+	Role::ScrollPane,
+	Role::LayeredPane,
+	Role::Viewport,
+	Role::Filler,
+	Role::Section,
+	Role::Form,
+	Role::Grouping,
+	Role::PageTabList,
+	Role::ToolBar,
+	Role::ToolTip,
+	Role::MenuBar,
+	Role::Menu,
+	Role::List,
+	Role::Table,
+	Role::Tree,
+	Role::TreeTable,
+	Role::Table,
+	Role::Canvas,
+	Role::DocumentFrame,
+	Role::Application,
+	Role::DesktopFrame,
+	Role::Footnote,
+	Role::Article,
+	Role::Landmark,
+];
+
 impl Default for ComboSets {
 	fn default() -> Self {
 		ComboSets::try_from([
@@ -630,6 +664,34 @@ impl Default for ComboSets {
 			(
 				Some(Mode::Browse),
 				ComboSet::try_from([
+					(
+						[Key::LeftArrow].try_into().unwrap(),
+						Navigate(
+							Direction::Backward,
+							ObjectMatchRule::builder()
+								.roles(
+									&SEMANTIC_ROLES,
+									MatchType::Any,
+								)
+								.invert(true)
+								.build(),
+						)
+						.into(),
+					),
+					(
+						[Key::RightArrow].try_into().unwrap(),
+						Navigate(
+							Direction::Forward,
+							ObjectMatchRule::builder()
+								.roles(
+									&SEMANTIC_ROLES,
+									MatchType::Any,
+								)
+								.invert(true)
+								.build(),
+						)
+						.into(),
+					),
 					(
 						[Key::KeyT].try_into().unwrap(),
 						StructuralNavigation(

--- a/input-server-keyboard/src/lib.rs
+++ b/input-server-keyboard/src/lib.rs
@@ -638,6 +638,22 @@ pub const SEMANTIC_ROLES: [Role; 30] = [
 	Role::Article,
 	Role::Landmark,
 ];
+/// General roles which cause a search to stop.
+///
+/// For example: in an HTML document, you do not want to search the browser menu or URL bar for
+/// something. Search is explicitly bounded by the `Role::DocumentFrame` in order to achieve this.
+pub const BOUNDING_ROLES: [Role; 10] = [
+	Role::Frame,
+	Role::DocumentFrame,
+	Role::DocumentWeb,
+	Role::Panel,
+	Role::ScrollPane,
+	Role::LayeredPane,
+	Role::Viewport,
+	Role::DocumentFrame,
+	Role::Application,
+	Role::DesktopFrame,
+];
 
 impl Default for ComboSets {
 	fn default() -> Self {
@@ -666,30 +682,50 @@ impl Default for ComboSets {
 				ComboSet::try_from([
 					(
 						[Key::LeftArrow].try_into().unwrap(),
-						Navigate(
-							Direction::Backward,
-							ObjectMatchRule::builder()
-								.roles(
-									&SEMANTIC_ROLES,
-									MatchType::Any,
-								)
-								.invert(true)
-								.build(),
-						)
+						Navigate {
+							direction: Direction::Backward,
+							find: Box::new(
+								ObjectMatchRule::builder()
+									.roles(
+										&SEMANTIC_ROLES,
+										MatchType::Any,
+									)
+									.invert(true)
+									.build(),
+							),
+							bound: Box::new(
+								ObjectMatchRule::builder()
+									.roles(
+										&BOUNDING_ROLES,
+										MatchType::Any,
+									)
+									.build(),
+							),
+						}
 						.into(),
 					),
 					(
 						[Key::RightArrow].try_into().unwrap(),
-						Navigate(
-							Direction::Forward,
-							ObjectMatchRule::builder()
-								.roles(
-									&SEMANTIC_ROLES,
-									MatchType::Any,
-								)
-								.invert(true)
-								.build(),
-						)
+						Navigate {
+							direction: Direction::Forward,
+							find: Box::new(
+								ObjectMatchRule::builder()
+									.roles(
+										&SEMANTIC_ROLES,
+										MatchType::Any,
+									)
+									.invert(true)
+									.build(),
+							),
+							bound: Box::new(
+								ObjectMatchRule::builder()
+									.roles(
+										&BOUNDING_ROLES,
+										MatchType::Any,
+									)
+									.build(),
+							),
+						}
 						.into(),
 					),
 					(

--- a/input-server-keyboard/src/lib.rs
+++ b/input-server-keyboard/src/lib.rs
@@ -41,6 +41,7 @@ pub const ACTIVATION_KEY: Key = Key::CapsLock;
 #[derive(Eq, PartialEq, Clone, Default)]
 #[repr(transparent)]
 pub struct KeySet {
+    // TODO: add activation key
 	inner: Vec<Key>,
 }
 
@@ -284,6 +285,8 @@ pub enum ComboError {
 #[derive(Clone, Eq, PartialEq, Default)]
 #[repr(transparent)]
 pub struct ComboSet {
+    // TODO: there should be an activation thing here in a tuple:
+    // (KeySet, bool), or a wrapper struct
 	inner: Vec<(KeySet, OdiliaEvent)>,
 }
 impl std::fmt::Debug for ComboSet {
@@ -458,6 +461,9 @@ pub enum SetError {
 #[derive(Clone, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct ComboSets {
+    // TODO: add extra checks here to ensure there isn't overlap on un-preefivxed/same-prefixed
+    // keys
+    // TODO: add another check/field for the list of activation keys
 	inner: Vec<(Option<Mode>, ComboSet)>,
 }
 impl std::fmt::Debug for ComboSets {
@@ -819,12 +825,16 @@ impl<'a> IntoIterator for &'a ComboSets {
 #[derive(Debug)]
 pub struct State {
 	/// If the activation key ([`crate::ACTIVATION_KEY`]) is pressed.
+    // TODO: remove; handle via combo sets
 	pub activation_key_pressed: bool,
 	/// Which mode the screen reader is in.
 	pub mode: Mode,
 	/// All pressed keys _after_ activation is pressed.
 	pub pressed: Vec<Key>,
 	/// List of key combos.
+    // NOTE: If you add a activatiable key, that key can no longer be passed through
+    // I don't see a way around that.
+    // So be very careful adding activation keys. 
 	pub combos: ComboSets,
 	/// A synchronous channel to send events to.
 	/// The receiver will send them over a socket to the main Odilia process.
@@ -839,6 +849,8 @@ pub struct State {
 ///
 /// If the [`State`]'s [`SyncSender`] for the [`OdiliaEvent`] is unable to be sent to.
 pub fn callback(event: Event, state: &mut State) -> Option<Event> {
+    // TODO: make sure to check the _individual_ activation keys!
+    // lack thereof is also an indication of how to handle it
 	tracing::debug!("Callback called for {event:?}");
 	match (event.event_type, state.activation_key_pressed) {
 		// if capslock is pressed while activation is disabled

--- a/odilia/src/handlers/atspi.rs
+++ b/odilia/src/handlers/atspi.rs
@@ -117,7 +117,7 @@ pub async fn caret_moved(
 				return Some(Speak(text_slice, Priority::Text).into());
 			}
 		} else {
-			return Some(Speak(text.to_string(), Priority::Text).into());
+			return Some(Speak(text.clone(), Priority::Text).into());
 		}
 	}
 	None

--- a/odilia/src/handlers/commands.rs
+++ b/odilia/src/handlers/commands.rs
@@ -1,13 +1,20 @@
 use std::{process::Child, time::Duration};
 
+use atspi::{
+	proxy::{accessible::AccessibleProxy, proxy_ext::ProxyExt},
+	ScrollType,
+};
 use odilia_common::{
-	command::{CaretPos, Focus, Quit, Speak},
+	command::{CaretPos, Focus, Move, Quit, Speak},
 	errors::OdiliaError,
 };
 use ssip::Request;
+use tracing::{error, trace};
+use zbus::proxy::CacheProperties;
 
 use crate::state::{
-	AccessibleHistory, ChildrenPids, Command, CurrentCaretPos, ShutdownToken, Speech,
+	AccessibleHistory, ChildrenPids, Command, Connection, CurrentCaretPos, ShutdownToken,
+	Speech,
 };
 
 #[tracing::instrument(ret, err, level = "debug")]
@@ -43,6 +50,39 @@ pub async fn new_focused_item(
 	AccessibleHistory(old_focus): AccessibleHistory,
 ) -> Result<(), OdiliaError> {
 	let _ = old_focus.lock()?.push(new_focus);
+	Ok(())
+}
+
+// NOTE: DO NOT UPDATE STATE HERE!
+//
+// This is for when Odilia has requested a change of focus via AT-SPI.
+// All state management, speaking, etc. will happen once the focus event makes its way back through
+// the handlers.
+#[tracing::instrument(ret, err)]
+pub async fn move_focus(
+	Command(Move(new_focus)): Command<Move>,
+	Connection(con): Connection,
+) -> Result<(), OdiliaError> {
+	let proxies = AccessibleProxy::builder(&con)
+		.cache_properties(CacheProperties::No)
+		.path(new_focus.id.clone())?
+		.destination(new_focus.sender.clone())?
+		.build()
+		.await?
+		.proxies()
+		.await?;
+	let live_item = proxies.component().await?;
+	if !live_item.grab_focus().await? {
+		error!("Unable to get focus on new item: {new_focus:?}");
+	}
+	if !live_item.scroll_to(ScrollType::TopLeft).await? {
+		error!("Unable to scroll to new item; this is usually because the item is invalid!");
+	}
+	let Ok(text_item) = proxies.text().await else {
+		trace!("New focus is not a text item");
+		return Ok(());
+	};
+	text_item.set_caret_offset(0).await?;
 	Ok(())
 }
 

--- a/odilia/src/handlers/commands.rs
+++ b/odilia/src/handlers/commands.rs
@@ -1,11 +1,14 @@
-use odilia_common::{
-	command::{CaretPos, Focus, Speak, TryIntoCommands},
-	errors::OdiliaError,
-	events::{StopSpeech, StructuralNavigation},
-};
-use ssip::{Priority, Request};
+use std::{process::Child, time::Duration};
 
-use crate::state::{AccessibleHistory, Command, CurrentCaretPos, InputEvent, Speech};
+use odilia_common::{
+	command::{CaretPos, Focus, Quit, Speak},
+	errors::OdiliaError,
+};
+use ssip::Request;
+
+use crate::state::{
+	AccessibleHistory, ChildrenPids, Command, CurrentCaretPos, ShutdownToken, Speech,
+};
 
 #[tracing::instrument(ret, err, level = "debug")]
 pub async fn speak(
@@ -53,13 +56,20 @@ pub async fn new_caret_pos(
 }
 
 #[tracing::instrument(ret)]
-pub async fn stop_speech(InputEvent(_): InputEvent<StopSpeech>) -> impl TryIntoCommands {
-	(Priority::Text, "Stop speech")
-}
-
-#[tracing::instrument(ret)]
-pub async fn structural_nav(
-	InputEvent(sn): InputEvent<StructuralNavigation>,
-) -> impl TryIntoCommands {
-	(Priority::Text, format!("Navigate to {}, {:?}", sn.1, sn.0))
+pub async fn quit_cmd(
+	Command(Quit): Command<Quit>,
+	ShutdownToken(token): ShutdownToken,
+	ChildrenPids(pids): ChildrenPids,
+) -> Result<(), OdiliaError> {
+	let timeout_duration = Duration::from_secs(5); //todo: perhaps take this from the configuration file at some point
+	tracing::debug!("Asking all processes to stop.");
+	pids.lock()
+		.expect("Unable to lock mutex!")
+		.iter_mut()
+		.try_for_each(Child::kill)
+		.expect("Unable to kill child processes");
+	tracing::debug!("cancelling all tokens");
+	token.cancel();
+	tracing::debug!(?timeout_duration, "waiting for all tasks to finish");
+	Ok(())
 }

--- a/odilia/src/handlers/input.rs
+++ b/odilia/src/handlers/input.rs
@@ -1,6 +1,6 @@
 use odilia_common::{
 	command::{Quit as QuitCommand, TryIntoCommands},
-	events::{ChangeMode, Quit, StopSpeech, StructuralNavigation},
+	events::{ChangeMode, Navigate, Quit, StopSpeech, StructuralNavigation},
 };
 use ssip::Priority;
 
@@ -26,4 +26,9 @@ pub async fn structural_nav(
 	InputEvent(sn): InputEvent<StructuralNavigation>,
 ) -> impl TryIntoCommands {
 	(Priority::Text, format!("Navigate to {}, {:?}", sn.1, sn.0))
+}
+
+#[tracing::instrument(ret)]
+pub async fn navigate(InputEvent(nav): InputEvent<Navigate>) {
+	todo!()
 }

--- a/odilia/src/handlers/input.rs
+++ b/odilia/src/handlers/input.rs
@@ -1,10 +1,10 @@
 use odilia_common::{
-	command::{Quit as QuitCommand, TryIntoCommands},
+	command::{Focus, Move, Quit as QuitCommand, TryIntoCommands},
 	events::{ChangeMode, Navigate, Quit, StopSpeech, StructuralNavigation},
 };
 use ssip::Priority;
 
-use crate::InputEvent;
+use crate::{state::NavigateTo, InputEvent};
 
 #[tracing::instrument(ret)]
 pub async fn change_mode(InputEvent(cm): InputEvent<ChangeMode>) -> impl TryIntoCommands {
@@ -29,6 +29,13 @@ pub async fn structural_nav(
 }
 
 #[tracing::instrument(ret)]
-pub async fn navigate(InputEvent(nav): InputEvent<Navigate>) {
-	todo!()
+pub async fn navigate(
+	InputEvent(nav): InputEvent<Navigate>,
+	NavigateTo(maybe_item): NavigateTo,
+) -> impl TryIntoCommands {
+	if let Some(item) = maybe_item {
+		Ok(vec![Move(item.object).into()])
+	} else {
+		Ok(vec![(Priority::Text, "No item found!").into()])
+	}
 }

--- a/odilia/src/handlers/input.rs
+++ b/odilia/src/handlers/input.rs
@@ -1,4 +1,7 @@
-use odilia_common::{command::TryIntoCommands, events::ChangeMode};
+use odilia_common::{
+	command::{Quit as QuitCommand, TryIntoCommands},
+	events::{ChangeMode, Quit, StopSpeech, StructuralNavigation},
+};
 use ssip::Priority;
 
 use crate::InputEvent;
@@ -6,4 +9,21 @@ use crate::InputEvent;
 #[tracing::instrument(ret)]
 pub async fn change_mode(InputEvent(cm): InputEvent<ChangeMode>) -> impl TryIntoCommands {
 	(Priority::Text, format!("{:?} mode", cm.0))
+}
+
+#[tracing::instrument(ret)]
+pub async fn quit_input(InputEvent(cm): InputEvent<Quit>) -> impl TryIntoCommands {
+	QuitCommand
+}
+
+#[tracing::instrument(ret)]
+pub async fn stop_speech(InputEvent(_): InputEvent<StopSpeech>) -> impl TryIntoCommands {
+	(Priority::Text, "Stop speech")
+}
+
+#[tracing::instrument(ret)]
+pub async fn structural_nav(
+	InputEvent(sn): InputEvent<StructuralNavigation>,
+) -> impl TryIntoCommands {
+	(Priority::Text, format!("Navigate to {}, {:?}", sn.1, sn.0))
 }

--- a/odilia/src/handlers/mod.rs
+++ b/odilia/src/handlers/mod.rs
@@ -1,7 +1,9 @@
 mod atspi;
 mod commands;
 mod input;
+mod signal;
 
 pub use atspi::*;
 pub use commands::*;
 pub use input::*;
+pub use signal::*;

--- a/odilia/src/handlers/signal.rs
+++ b/odilia/src/handlers/signal.rs
@@ -1,0 +1,12 @@
+use odilia_common::command::{Quit as QuitCommand, TryIntoCommands};
+use ssip::Priority;
+
+use crate::{signal, state::Signal};
+
+pub async fn sigint_quit(_: Signal<signal::Int>) -> impl TryIntoCommands {
+	QuitCommand
+}
+
+pub async fn sigusr1_reload_config(_: Signal<signal::Usr1>) -> impl TryIntoCommands {
+	(Priority::Message, "Reload config")
+}

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -32,9 +32,9 @@ use futures_lite::{
 };
 use futures_util::FutureExt as FatExt;
 use handlers::{
-	caret_moved, caret_moved_update_state, change_mode, doc_loaded, focused, new_caret_pos,
-	new_focused_item, quit_cmd, quit_input, sigint_quit, sigusr1_reload_config, speak,
-	state_set, stop_speech, structural_nav,
+	caret_moved, caret_moved_update_state, change_mode, doc_loaded, focused, move_focus,
+	navigate, new_caret_pos, new_focused_item, quit_cmd, quit_input, sigint_quit,
+	sigusr1_reload_config, speak, state_set, stop_speech, structural_nav,
 };
 use odilia_cache::{cache_handler_task, Cache, CacheActor};
 use odilia_common::{
@@ -211,6 +211,7 @@ async fn async_main() -> Result<(), OdiliaError> {
 	let handlers = Handlers::new(state.clone(), token.clone())
 		.command_listener(speak)
 		.command_listener(new_focused_item)
+		.command_listener(move_focus)
 		.command_listener(new_caret_pos)
 		.command_listener(new_caret_pos)
 		.command_listener(quit_cmd)
@@ -224,6 +225,7 @@ async fn async_main() -> Result<(), OdiliaError> {
 		.input_listener(change_mode)
 		.input_listener(quit_input)
 		.input_listener(structural_nav)
+		.input_listener(navigate)
 		.signal_listener(sigint_quit)
 		.signal_listener(sigusr1_reload_config);
 

--- a/odilia/src/main.rs
+++ b/odilia/src/main.rs
@@ -12,6 +12,7 @@
 mod cli;
 mod handlers;
 mod logging;
+mod signal;
 mod state;
 mod tower;
 use std::{
@@ -19,13 +20,11 @@ use std::{
 	path::{Path, PathBuf},
 	process::{exit, Child, Command as ProcCommand},
 	sync::Arc,
-	time::Duration,
 };
 
 use async_channel::bounded;
 use async_executor::StaticExecutor;
-use async_signal::{Signal, Signals};
-use atspi::events::{document, object};
+use atspi::events::event_wrappers;
 use futures_concurrency::future::{Join, TryJoin};
 use futures_lite::{
 	future::{block_on, FutureExt},
@@ -34,7 +33,8 @@ use futures_lite::{
 use futures_util::FutureExt as FatExt;
 use handlers::{
 	caret_moved, caret_moved_update_state, change_mode, doc_loaded, focused, new_caret_pos,
-	new_focused_item, speak, state_set, stop_speech, structural_nav,
+	new_focused_item, quit_cmd, quit_input, sigint_quit, sigusr1_reload_config, speak,
+	state_set, stop_speech, structural_nav,
 };
 use odilia_cache::{cache_handler_task, Cache, CacheActor};
 use odilia_common::{
@@ -148,26 +148,6 @@ async fn notifications_monitor(
 	}
 	Ok(())
 }
-#[tracing::instrument(skip_all, err)]
-async fn sigterm_signal_watcher(
-	token: CancellationToken,
-	state: Arc<ScreenReaderState>,
-) -> Result<(), OdiliaError> {
-	let timeout_duration = Duration::from_secs(5); //todo: perhaps take this from the configuration file at some point
-	let mut signals = Signals::new([Signal::Int])?;
-	signals.next()
-		.instrument(tracing::debug_span!("Watching for Ctrl+C"))
-		.await;
-	tracing::debug!("Asking all processes to stop.");
-	(*state.children_pids.lock().expect("Unable to lock mutex!"))
-		.iter_mut()
-		.try_for_each(Child::kill)
-		.expect("Able to kill child processes");
-	tracing::debug!("cancelling all tokens");
-	token.cancel();
-	tracing::debug!(?timeout_duration, "waiting for all tasks to finish");
-	Ok(())
-}
 
 static EXECUTOR: StaticExecutor = StaticExecutor::new();
 
@@ -175,6 +155,7 @@ fn main() -> Result<(), OdiliaError> {
 	block_on(EXECUTOR.run(async_main()))
 }
 
+#[allow(clippy::too_many_lines)]
 async fn async_main() -> Result<(), OdiliaError> {
 	let ex = &EXECUTOR;
 	let args = Args::from_cli_args()?;
@@ -206,7 +187,8 @@ async fn async_main() -> Result<(), OdiliaError> {
 	// lots of space for caching just in case...
 	let (cache_tx, cache_rx) = bounded(4096);
 	let cache = CacheActor::new(cache_tx);
-	let state = Arc::new(ScreenReaderState::new(ssip_req_tx, config, cache).await?);
+	let state =
+		Arc::new(ScreenReaderState::new(ssip_req_tx, config, cache, token.clone()).await?);
 	let ssip = odilia_tts::create_ssip_client().await?;
 
 	if state.say(Priority::Message, "Welcome to Odilia!".to_string()).await {
@@ -219,20 +201,19 @@ async fn async_main() -> Result<(), OdiliaError> {
 
 	// Register events
 	(
-		state.register_event::<object::StateChangedEvent>(),
-		state.register_event::<object::TextCaretMovedEvent>(),
-		state.register_event::<document::LoadCompleteEvent>(),
-		//TODO: we don't handle these yet!
-		// state.add_cache_match_rule(),
+		state.register_event::<event_wrappers::ObjectEvents>(),
+		state.register_event::<event_wrappers::DocumentEvents>(),
 	)
 		.try_join()
 		.await?;
 
 	// load handlers
-	let handlers = Handlers::new(state.clone())
+	let handlers = Handlers::new(state.clone(), token.clone())
 		.command_listener(speak)
 		.command_listener(new_focused_item)
 		.command_listener(new_caret_pos)
+		.command_listener(new_caret_pos)
+		.command_listener(quit_cmd)
 		//.command_listener(set_state)
 		.atspi_listener(doc_loaded)
 		.atspi_listener(caret_moved_update_state)
@@ -241,7 +222,10 @@ async fn async_main() -> Result<(), OdiliaError> {
 		.atspi_listener(state_set)
 		.input_listener(stop_speech)
 		.input_listener(change_mode)
-		.input_listener(structural_nav);
+		.input_listener(quit_input)
+		.input_listener(structural_nav)
+		.signal_listener(sigint_quit)
+		.signal_listener(sigusr1_reload_config);
 
 	let ssip_event_receiver =
 		odilia_tts::handle_ssip_commands(ssip, ssip_req_rx, token.clone());
@@ -271,7 +255,7 @@ async fn async_main() -> Result<(), OdiliaError> {
 			}
 		}
 	};
-	let atspi_handlers_task = handlers.clone().atspi_handler(ev_rx, token.clone());
+	let atspi_handlers_task = handlers.clone().atspi_handler(ev_rx);
 	let listener = odilia_input::setup_input_server()
 		.await
 		.expect("We should be able to set up input server; without it, Odilia cannot be controlled via input methods");
@@ -279,7 +263,8 @@ async fn async_main() -> Result<(), OdiliaError> {
 		.for_each(|fut| {
 			ex.spawn(fut).detach();
 		});
-	let input_handler = handlers.input_handler(input_rx, token.clone());
+	let input_handler = handlers.clone().input_handler(input_rx);
+	let signal_handler = handlers.signal_handler();
 	let child = try_spawn_input_server(&state.config.input.method)?;
 	state.add_child_proc(child).expect("Able to add child to process!");
 
@@ -295,9 +280,9 @@ async fn async_main() -> Result<(), OdiliaError> {
 		input_task,
 		input_handler,
 		cache_handler,
+		signal_handler,
 	)
 		.join();
-	ex.spawn(sigterm_signal_watcher(token, Arc::clone(&state))).detach();
 	let _ = joined_tasks.await;
 	tracing::debug!("All listeners have stopped.");
 	tracing::debug!("Goodbye, Odilia!");

--- a/odilia/src/signal.rs
+++ b/odilia/src/signal.rs
@@ -1,0 +1,62 @@
+use async_signal::Signal;
+
+use crate::tower::choice::ChooserStatic;
+
+pub trait SignalType {}
+
+macro_rules! impl_sig {
+	($type:ident, $orig:path) => {
+		#[allow(dead_code)]
+		#[derive(Clone, Copy, Debug)]
+		pub struct $type;
+		impl SignalType for $type {}
+		impl ChooserStatic<Signal> for $type {
+			fn identifier() -> Signal {
+				$orig
+			}
+		}
+		impl TryFrom<Signal> for $type {
+			type Error = String;
+			fn try_from(sig: Signal) -> Result<$type, Self::Error> {
+				if $orig == sig {
+					Ok($type)
+				} else {
+					Err(format!(
+						"Invalid signal type for {:?}: {:?}",
+						$type, sig
+					))
+				}
+			}
+		}
+	};
+}
+
+impl_sig!(Hup, Signal::Hup);
+impl_sig!(Int, Signal::Int);
+impl_sig!(Quit, Signal::Quit);
+impl_sig!(Ill, Signal::Ill);
+impl_sig!(Trap, Signal::Trap);
+impl_sig!(Abort, Signal::Abort);
+impl_sig!(Bus, Signal::Bus);
+impl_sig!(Fpe, Signal::Fpe);
+impl_sig!(Kill, Signal::Kill);
+impl_sig!(Usr1, Signal::Usr1);
+impl_sig!(Segv, Signal::Segv);
+impl_sig!(Usr2, Signal::Usr2);
+impl_sig!(Pipe, Signal::Pipe);
+impl_sig!(Alarm, Signal::Alarm);
+impl_sig!(Term, Signal::Term);
+impl_sig!(Child, Signal::Child);
+impl_sig!(Cont, Signal::Cont);
+impl_sig!(Stop, Signal::Stop);
+impl_sig!(Tstp, Signal::Tstp);
+impl_sig!(Ttin, Signal::Ttin);
+impl_sig!(Ttou, Signal::Ttou);
+impl_sig!(Urg, Signal::Urg);
+impl_sig!(Xcpu, Signal::Xcpu);
+impl_sig!(Xfsz, Signal::Xfsz);
+impl_sig!(Vtalarm, Signal::Vtalarm);
+impl_sig!(Prof, Signal::Prof);
+impl_sig!(Winch, Signal::Winch);
+impl_sig!(Io, Signal::Io);
+impl_sig!(Sys, Signal::Sys);

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -18,7 +18,7 @@ use odilia_common::{
 	cache::AccessiblePrimitive,
 	command::CommandType,
 	errors::OdiliaError,
-	events::EventType,
+	events::{EventType, ScreenReaderEvent},
 	settings::{speech::PunctuationSpellingMode, ApplicationConfig},
 	Result as OdiliaResult,
 };
@@ -67,6 +67,8 @@ impl<C> TryFromState<Arc<ScreenReaderState>, C> for CurrentCaretPos {
 #[derive(Debug, Clone)]
 pub struct LastFocused(pub AccessiblePrimitive);
 #[derive(Debug, Clone)]
+pub struct NavigateTo(pub AccessiblePrimitive);
+#[derive(Debug, Clone)]
 pub struct ChildrenPids(pub Arc<Mutex<Vec<Child>>>);
 #[derive(Debug, Clone)]
 pub struct ShutdownToken(pub CancellationToken);
@@ -98,6 +100,26 @@ where
 	type Future = Ready<Result<InputEvent<E>, Self::Error>>;
 	fn try_from_state(_state: Arc<ScreenReaderState>, i_ev: E) -> Self::Future {
 		ok(InputEvent(i_ev))
+	}
+}
+impl<E> TryFromState<Arc<ScreenReaderState>, E> for NavigateTo
+where
+	E: EventType + Clone + Debug,
+	ScreenReaderEvent: From<E>,
+{
+	type Error = OdiliaError;
+	type Future = Ready<Result<NavigateTo, Self::Error>>;
+	fn try_from_state(state: Arc<ScreenReaderState>, i_ev: E) -> Self::Future {
+		let ScreenReaderEvent::Navigate(nav) = i_ev.clone().into() else {
+			return err(format!(
+				"Invalid type of input event ({:?}) for extractor {:?}",
+				i_ev,
+				std::any::type_name::<NavigateTo>()
+			)
+			.into());
+		};
+		// TODO: go get the right item via cache
+		todo!()
 	}
 }
 

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -22,10 +22,11 @@ use odilia_common::{
 	settings::{speech::PunctuationSpellingMode, ApplicationConfig},
 	Result as OdiliaResult,
 };
+use smol_cancellation_token::CancellationToken;
 use ssip_client_async::{Priority, PunctuationMode, Request as SSIPRequest};
 use tracing::{Instrument, Level};
 
-use crate::tower::from_state::TryFromState;
+use crate::{signal::SignalType, tower::from_state::TryFromState};
 
 impl Debug for ScreenReaderState {
 	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
@@ -42,6 +43,8 @@ pub struct ScreenReaderState {
 	pub cache_actor: CacheActor,
 	pub config: Arc<ApplicationConfig>,
 	pub children_pids: Arc<Mutex<Vec<Child>>>,
+	/// Used to shutdown the entire screen reader
+	pub shutdown_token: CancellationToken,
 }
 #[derive(Debug, Clone)]
 pub struct AccessibleHistory(pub Arc<Mutex<CircularQueue<AccessiblePrimitive>>>);
@@ -63,11 +66,20 @@ impl<C> TryFromState<Arc<ScreenReaderState>, C> for CurrentCaretPos {
 
 #[derive(Debug, Clone)]
 pub struct LastFocused(pub AccessiblePrimitive);
+#[derive(Debug, Clone)]
+pub struct ChildrenPids(pub Arc<Mutex<Vec<Child>>>);
+#[derive(Debug, Clone)]
+pub struct ShutdownToken(pub CancellationToken);
 #[derive(Debug)]
 pub struct CurrentCaretPos(pub Arc<AtomicUsize>);
 #[derive(Debug, Clone)]
 pub struct LastCaretPos(pub usize);
 pub struct Speech(pub Sender<SSIPRequest>);
+#[derive(Debug)]
+pub struct Signal<T>(pub T)
+where
+	T: SignalType;
+
 #[derive(Debug)]
 pub struct Command<T>(pub T)
 where
@@ -100,6 +112,17 @@ where
 	}
 }
 
+impl<S> TryFromState<Arc<ScreenReaderState>, S> for Signal<S>
+where
+	S: SignalType,
+{
+	type Error = OdiliaError;
+	type Future = Ready<Result<Signal<S>, Self::Error>>;
+	fn try_from_state(_state: Arc<ScreenReaderState>, sig: S) -> Self::Future {
+		ok(Signal(sig))
+	}
+}
+
 impl<C> TryFromState<Arc<ScreenReaderState>, C> for Speech
 where
 	C: CommandType + Debug,
@@ -108,6 +131,26 @@ where
 	type Future = Ready<Result<Speech, Self::Error>>;
 	fn try_from_state(state: Arc<ScreenReaderState>, _cmd: C) -> Self::Future {
 		ok(Speech(state.ssip.clone()))
+	}
+}
+impl<C> TryFromState<Arc<ScreenReaderState>, C> for ShutdownToken
+where
+	C: CommandType + Debug,
+{
+	type Error = OdiliaError;
+	type Future = Ready<Result<ShutdownToken, Self::Error>>;
+	fn try_from_state(state: Arc<ScreenReaderState>, _cmd: C) -> Self::Future {
+		ok(ShutdownToken(state.shutdown_token.clone()))
+	}
+}
+impl<C> TryFromState<Arc<ScreenReaderState>, C> for ChildrenPids
+where
+	C: CommandType + Debug,
+{
+	type Error = OdiliaError;
+	type Future = Ready<Result<ChildrenPids, Self::Error>>;
+	fn try_from_state(state: Arc<ScreenReaderState>, _cmd: C) -> Self::Future {
+		ok(ChildrenPids(Arc::clone(&state.children_pids)))
 	}
 }
 
@@ -156,6 +199,7 @@ impl ScreenReaderState {
 		ssip: Sender<SSIPRequest>,
 		config: ApplicationConfig,
 		cache_actor: CacheActor,
+		shutdown_token: CancellationToken,
 	) -> Result<ScreenReaderState, OdiliaError> {
 		let atspi = AccessibilityConnection::new()
 			.instrument(tracing::info_span!("connecting to at-spi bus"))
@@ -215,6 +259,7 @@ impl ScreenReaderState {
 			cache_actor,
 			config: Arc::new(config),
 			children_pids: Arc::new(Mutex::new(Vec::new())),
+			shutdown_token,
 		})
 	}
 

--- a/odilia/src/state.rs
+++ b/odilia/src/state.rs
@@ -12,13 +12,14 @@ use atspi::{
 	Event,
 };
 use circular_queue::CircularQueue;
-use futures_util::future::{err, ok, Ready};
-use odilia_cache::{CacheActor, CacheItem, CacheRequest, CacheResponse, Item};
+use futures_lite::future::Boxed;
+use futures_util::future::{err, ok, Ready, TryFutureExt};
+use odilia_cache::{CacheActor, CacheItem, CacheRequest, CacheResponse, FoundItem, Item};
 use odilia_common::{
 	cache::AccessiblePrimitive,
 	command::CommandType,
 	errors::OdiliaError,
-	events::{EventType, ScreenReaderEvent},
+	events::{EventType, Navigate},
 	settings::{speech::PunctuationSpellingMode, ApplicationConfig},
 	Result as OdiliaResult,
 };
@@ -67,7 +68,9 @@ impl<C> TryFromState<Arc<ScreenReaderState>, C> for CurrentCaretPos {
 #[derive(Debug, Clone)]
 pub struct LastFocused(pub AccessiblePrimitive);
 #[derive(Debug, Clone)]
-pub struct NavigateTo(pub AccessiblePrimitive);
+pub struct Connection(pub zbus::Connection);
+#[derive(Debug, Clone)]
+pub struct NavigateTo(pub Option<CacheItem>);
 #[derive(Debug, Clone)]
 pub struct ChildrenPids(pub Arc<Mutex<Vec<Child>>>);
 #[derive(Debug, Clone)]
@@ -102,24 +105,36 @@ where
 		ok(InputEvent(i_ev))
 	}
 }
-impl<E> TryFromState<Arc<ScreenReaderState>, E> for NavigateTo
-where
-	E: EventType + Clone + Debug,
-	ScreenReaderEvent: From<E>,
-{
+impl TryFromState<Arc<ScreenReaderState>, Navigate> for NavigateTo {
 	type Error = OdiliaError;
-	type Future = Ready<Result<NavigateTo, Self::Error>>;
-	fn try_from_state(state: Arc<ScreenReaderState>, i_ev: E) -> Self::Future {
-		let ScreenReaderEvent::Navigate(nav) = i_ev.clone().into() else {
-			return err(format!(
-				"Invalid type of input event ({:?}) for extractor {:?}",
-				i_ev,
-				std::any::type_name::<NavigateTo>()
-			)
-			.into());
-		};
-		// TODO: go get the right item via cache
-		todo!()
+	type Future = Boxed<Result<NavigateTo, Self::Error>>;
+	fn try_from_state(state: Arc<ScreenReaderState>, nav: Navigate) -> Self::Future {
+		let last_focused_gaurd = state
+			.accessible_history
+			.lock()
+			.expect("Unable to lock accessible history!");
+		let start = last_focused_gaurd
+			.iter()
+			.nth(0)
+			.cloned()
+			.expect("Can not find a previously focused element!");
+		// explicitly drop so we don't hold it for the duration of the future
+		drop(last_focused_gaurd);
+
+		Box::pin(async move {
+			state.cache_actor
+				.request(CacheRequest::Find(
+					start,
+					nav.direction,
+					nav.find,
+					nav.bound,
+				))
+				.map_ok(|cr| match cr {
+					CacheResponse::Find(FoundItem(ci)) => NavigateTo(ci),
+					e => panic!("Inappropriate response: {e:?}"),
+				})
+				.await
+		})
 	}
 }
 
@@ -131,6 +146,17 @@ where
 	type Future = Ready<Result<Command<C>, Self::Error>>;
 	fn try_from_state(_state: Arc<ScreenReaderState>, cmd: C) -> Self::Future {
 		ok(Command(cmd))
+	}
+}
+
+impl<C> TryFromState<Arc<ScreenReaderState>, C> for Connection
+where
+	C: CommandType + Clone + Debug,
+{
+	type Error = OdiliaError;
+	type Future = Ready<Result<Connection, Self::Error>>;
+	fn try_from_state(state: Arc<ScreenReaderState>, _cmd: C) -> Self::Future {
+		ok(Connection(state.atspi.connection().clone()))
 	}
 }
 

--- a/odilia/src/tower/choice.rs
+++ b/odilia/src/tower/choice.rs
@@ -5,6 +5,7 @@ use std::{
 	task::{Context, Poll},
 };
 
+use async_signal::Signal;
 use atspi::{
 	events::{DBusInterface, DBusMember},
 	Event, EventTypeProperties,
@@ -65,6 +66,9 @@ where
 	{
 		self.services.entry(k)
 	}
+	pub fn keys(&self) -> impl Iterator<Item = &K> {
+		self.services.keys()
+	}
 }
 
 impl<K, S, Req> Service<Req> for ChoiceService<K, S, Req>
@@ -121,6 +125,14 @@ where
 {
 	fn identifier() -> ScreenReaderEventDiscriminants {
 		E::ETYPE
+	}
+}
+
+// stub impl, since Signal is an i32 internally it implements all the methods we need, no need it
+// change its identifier to another, simpler type
+impl Chooser<Signal> for Signal {
+	fn identifier(&self) -> Signal {
+		*self
 	}
 }
 

--- a/odilia/src/tower/handlers.rs
+++ b/odilia/src/tower/handlers.rs
@@ -3,7 +3,9 @@
 use std::{fmt::Debug, sync::Arc};
 
 use async_channel::Receiver;
+use async_signal::{Signal, Signals};
 use atspi::{AtspiError, Event, EventProperties, EventTypeProperties};
+use futures_lite::stream::StreamExt;
 use odilia_common::{
 	command::{
 		CommandType, OdiliaCommand as Command,
@@ -16,6 +18,7 @@ use tower::{util::BoxCloneService, Service, ServiceExt};
 
 use crate::{
 	or_cancel,
+	signal::SignalType,
 	state::ScreenReaderState,
 	tower::{
 		async_try::AsyncTryFrom,
@@ -35,10 +38,12 @@ type ResultList = Vec<OdiliaResult<()>>;
 type AtspiHandler = BoxCloneService<Event, (), Error>;
 type CommandHandler = BoxCloneService<Command, (), Error>;
 type InputHandler = BoxCloneService<ScreenReaderEvent, (), Error>;
+type SignalHandler = BoxCloneService<Signal, (), Error>;
 
 #[derive(Clone)]
 pub struct Handlers {
 	state: Arc<ScreenReaderState>,
+	signal: ChoiceService<Signal, ServiceSet<SignalHandler>, Signal>,
 	atspi: ChoiceService<(&'static str, &'static str), ServiceSet<AtspiHandler>, Event>,
 	command: ChoiceService<CommandDiscriminants, ServiceSet<CommandHandler>, Command>,
 	input: ChoiceService<
@@ -46,20 +51,49 @@ pub struct Handlers {
 		ServiceSet<InputHandler>,
 		ScreenReaderEvent,
 	>,
+	token: crate::CancellationToken,
 }
 
 impl Handlers {
-	pub fn new(state: Arc<ScreenReaderState>) -> Self {
+	pub fn new(state: Arc<ScreenReaderState>, token: crate::CancellationToken) -> Self {
 		Handlers {
 			state,
 			atspi: ChoiceService::new(),
 			command: ChoiceService::new(),
 			input: ChoiceService::new(),
+			signal: ChoiceService::new(),
+			token,
+		}
+	}
+	pub async fn signal_handler(mut self) {
+		let sig_vec: Vec<Signal> = self.signal.keys().copied().collect();
+		let mut sigs =
+			Signals::new(&sig_vec).expect("Unable to hook into signal registry!");
+		loop {
+			let maybe = or_cancel(sigs.next(), &self.token).await;
+			let Ok(maybe_sig) = maybe else {
+				return;
+			};
+			let Some(Ok(sig)) = maybe_sig else {
+				tracing::error!("Error sig: {maybe_sig:?}");
+				continue;
+			};
+			// NOTE: Why not use join_all(...) ?
+			// Because this drives the futures concurrently, and we want ordered handlers.
+			// Otherwise, we cannot guarentee that the caching functions get run first.
+			// we could move caching to a separate, ordered system, then parallelize the other functions,
+			// if we determine this is a performance problem.
+			if let Err(e) = self.signal.call(sig).await {
+				tracing::error!("{e:?}");
+			}
 		}
 	}
 	pub async fn command_handler(mut self, commands: Receiver<Command>) {
 		loop {
-			let maybe_cmd = commands.recv().await;
+			let maybe = or_cancel(commands.recv(), &self.token).await;
+			let Ok(maybe_cmd) = maybe else {
+				return;
+			};
 			let Ok(cmd) = maybe_cmd else {
 				tracing::error!("Error cmd: {maybe_cmd:?}");
 				continue;
@@ -75,13 +109,9 @@ impl Handlers {
 		}
 	}
 	#[tracing::instrument(skip_all)]
-	pub async fn atspi_handler(
-		mut self,
-		events: Receiver<Result<Event, AtspiError>>,
-		token: crate::CancellationToken,
-	) {
+	pub async fn atspi_handler(mut self, events: Receiver<Result<Event, AtspiError>>) {
 		loop {
-			let maybe = or_cancel(events.recv(), &token).await;
+			let maybe = or_cancel(events.recv(), &self.token).await;
 			let Ok(maybe_ev) = maybe else {
 				return;
 			};
@@ -95,14 +125,10 @@ impl Handlers {
 		}
 	}
 	#[tracing::instrument(skip_all)]
-	pub async fn input_handler(
-		mut self,
-		mut events: Receiver<ScreenReaderEvent>,
-		token: crate::CancellationToken,
-	) {
+	pub async fn input_handler(mut self, mut events: Receiver<ScreenReaderEvent>) {
 		std::pin::pin!(&mut events);
 		loop {
-			let maybe = or_cancel(events.recv(), &token).await;
+			let maybe = or_cancel(events.recv(), &self.token).await;
 			let Ok(maybe_ev) = maybe else {
 				return;
 			};
@@ -145,6 +171,45 @@ impl Handlers {
 			atspi: self.atspi,
 			command: self.command,
 			input: self.input,
+			signal: self.signal,
+			token: self.token,
+		}
+	}
+	pub fn signal_listener<H, T, R, S>(mut self, handler: H) -> Self
+	where
+		H: Handler<T, Response = R> + Send + Clone + 'static,
+		<H as Handler<T>>::Future: Send,
+		S: SignalType + ChooserStatic<Signal> + Send + 'static,
+		Signal: TryInto<S>,
+		OdiliaError: From<<Signal as TryInto<S>>::Error>
+			+ From<<T as TryFromState<Arc<ScreenReaderState>, S>>::Error>,
+		R: TryIntoCommands + Send + 'static,
+		T: TryFromState<Arc<ScreenReaderState>, S> + Send + 'static,
+		<T as TryFromState<Arc<ScreenReaderState>, S>>::Future: Send,
+		<T as TryFromState<Arc<ScreenReaderState>, S>>::Error: Send,
+	{
+		let bs = handler
+			.into_service()
+			.map_response_try_into_command()
+			.request_async_try_from()
+			.with_state(Arc::clone(&self.state))
+			.request_try_from()
+			.iter_into(self.command.clone())
+			.map_result(|res: OdiliaResult<Vec<OdiliaResult<ResultList>>>| {
+				res?.into_iter() // Remove outer result
+					.flatten() // Flatten out first vec
+					.flatten() // Flatten out ResultList
+					.collect::<Result<(), OdiliaError>>()
+			})
+			.boxed_clone();
+		self.signal.entry(S::identifier()).or_default().push(bs);
+		Self {
+			state: self.state,
+			atspi: self.atspi,
+			command: self.command,
+			input: self.input,
+			signal: self.signal,
+			token: self.token,
 		}
 	}
 	pub fn input_listener<H, T, R, E>(mut self, handler: H) -> Self
@@ -180,6 +245,8 @@ impl Handlers {
 			atspi: self.atspi,
 			command: self.command,
 			input: self.input,
+			signal: self.signal,
+			token: self.token,
 		}
 	}
 	pub fn atspi_listener<H, T, R, E>(mut self, handler: H) -> Self
@@ -226,6 +293,8 @@ impl Handlers {
 			atspi: self.atspi,
 			command: self.command,
 			input: self.input,
+			signal: self.signal,
+			token: self.token,
 		}
 	}
 }


### PR DESCRIPTION
- [X] Add signal handlers
- [x] Add capslock+arrow-based navigation
- [ ] Handle text cursor cases (the "next" element is not neecesarrily the next in the tree if the user is mid-text)
- [ ] Handle text inner items (when navigating, only read up until the object replacement character; if the user wants to continue they can use the "next" action to read the inner item)
- [ ] Anti-Feature: caret browsing/flat review. Make the caret controlled purely through Odilia.
- [ ] Allow non-capslock prefixed keybindings
    - [ ] Allow arbitrary activation keys
    - [ ] Ensure no overlap in fuzz testing
- [ ] Remove `Default` impl of keybindings
- [ ] Read keybindings from config file (via Odilia, not directly)